### PR TITLE
Add ACCESS-OM3 to list of packages to build

### DIFF
--- a/.github/workflows/build-and-push-image-build.yml
+++ b/.github/workflows/build-and-push-image-build.yml
@@ -10,6 +10,7 @@ jobs:
         package: [
           "oasis3-mct",
           "libaccessom2",
+          "access-om3",
         ]
         compiler: [
           {


### PR DESCRIPTION
For this to work, one needs to trigger the creation of the base image, so that it uses the latest version of ACCESS-NRI/spack_packages.