### PR TITLE
#6 ACCESS-NRI/spack_packages Git Version Option

### DIFF
--- a/.github/workflows/build-and-push-image-base-spack.yml
+++ b/.github/workflows/build-and-push-image-base-spack.yml
@@ -4,8 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       spack-packages-version:
-        required: false
+        required: true
+        type: string
         default: "main"
+        description: "Either a git commit hash, a tag, or a branch name for the ACCESS-NRI/spack_packages repository, which defaults to the main branch"
 
 jobs:
   build-and-push-image:
@@ -15,7 +17,7 @@ jobs:
       container-name: access-nri/base-spack
       dockerfile-directory: containers
       dockerfile-name: Dockerfile.base-spack
-      build-args: "SPACK_PACKAGES_VERSION=${{ inputs.spack-packages-version }}"
+      build-args: "SPACK_PACKAGES_VERSION=${{ github.event.inputs.spack-packages-version }}"
     secrets: 
       build-secrets: |
         "S3_ACCESS_KEY_ID=${{ secrets.S3_ACCESS_KEY_ID }}"

--- a/.github/workflows/build-and-push-image-base-spack.yml
+++ b/.github/workflows/build-and-push-image-base-spack.yml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
         default: "main"
-        description: "Either a git commit hash, a tag, or a branch name for the ACCESS-NRI/spack_packages repository, which defaults to the main branch"
+        description: "Either a git tag or branch name for the ACCESS-NRI/spack_packages repository, which defaults to the main branch"
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/build-and-push-image-base-spack.yml
+++ b/.github/workflows/build-and-push-image-base-spack.yml
@@ -2,6 +2,10 @@ name: Build and push access-nri/base-spack image
 
 on:
   workflow_dispatch:
+    inputs:
+      spack-packages-version:
+        required: false
+        default: "main"
 
 jobs:
   build-and-push-image:
@@ -11,6 +15,7 @@ jobs:
       container-name: access-nri/base-spack
       dockerfile-directory: containers
       dockerfile-name: Dockerfile.base-spack
+      build-args: "SPACK_PACKAGES_VERSION=${{ inputs.spack-packages-version }}"
     secrets: 
       build-secrets: |
         "S3_ACCESS_KEY_ID=${{ secrets.S3_ACCESS_KEY_ID }}"

--- a/.github/workflows/build-and-push-image-base-spack.yml
+++ b/.github/workflows/build-and-push-image-base-spack.yml
@@ -14,7 +14,7 @@ jobs:
     uses: access-nri/workflows/.github/workflows/build-and-push-image.yml@main
     with:
       container-registry: ghcr.io
-      container-name: access-nri/base-spack
+      container-name: access-nri/base-spack-${{ github.event.inputs.spack-packages-version }}
       dockerfile-directory: containers
       dockerfile-name: Dockerfile.base-spack
       build-args: "SPACK_PACKAGES_VERSION=${{ github.event.inputs.spack-packages-version }}"

--- a/containers/Dockerfile.base-spack
+++ b/containers/Dockerfile.base-spack
@@ -40,9 +40,7 @@ SHELL ["docker-shell"]
 RUN spack bootstrap now
 
 # Set up ACCESS Spack package repo
-RUN git clone https://github.com/ACCESS-NRI/spack_packages.git ${SPACK_PACKAGES_ROOT} && \
-    cd ${SPACK_PACKAGES_ROOT} && \
-    git checkout ${SPACK_PACKAGES_VERSION}
+RUN git clone -b ${SPACK_PACKAGES_VERSION} https://github.com/ACCESS-NRI/spack_packages.git ${SPACK_PACKAGES_ROOT}
 COPY repos.yaml $SPACK_ROOT/etc/spack/repos.yaml
 
 # TODO

--- a/containers/Dockerfile.base-spack
+++ b/containers/Dockerfile.base-spack
@@ -6,6 +6,8 @@ ENV SPACK_ROOT=/opt/spack
 ENV SPACK_PACKAGES_ROOT=/opt/spack_packages
 ENV GNUPGHOME=$SPACK_ROOT/opt/spack/gpg
 
+ARG SPACK_PACKAGES_VERSION
+
 RUN dnf -y group install "Development Tools"
 
 RUN dnf -y install \
@@ -38,7 +40,9 @@ SHELL ["docker-shell"]
 RUN spack bootstrap now
 
 # Set up ACCESS Spack package repo
-RUN git clone https://github.com/ACCESS-NRI/spack_packages.git $SPACK_PACKAGES_ROOT
+RUN git clone https://github.com/ACCESS-NRI/spack_packages.git ${SPACK_PACKAGES_ROOT} && \
+    cd ${SPACK_PACKAGES_ROOT} && \
+    git checkout SPACK_PACKAGES_VERSION
 COPY repos.yaml $SPACK_ROOT/etc/spack/repos.yaml
 
 # TODO

--- a/containers/Dockerfile.base-spack
+++ b/containers/Dockerfile.base-spack
@@ -42,7 +42,7 @@ RUN spack bootstrap now
 # Set up ACCESS Spack package repo
 RUN git clone https://github.com/ACCESS-NRI/spack_packages.git ${SPACK_PACKAGES_ROOT} && \
     cd ${SPACK_PACKAGES_ROOT} && \
-    git checkout SPACK_PACKAGES_VERSION
+    git checkout ${SPACK_PACKAGES_VERSION}
 COPY repos.yaml $SPACK_ROOT/etc/spack/repos.yaml
 
 # TODO


### PR DESCRIPTION
This PR adds in a required input to the build-and-publish-image-base-spack GitHub Action that specifies either a commit hash, tag or branch name for ACCESS-NRI/spack_packages. This defaults to `main`. 

Should close #6 !