### PR TITLE
Fix to spack_packages version option

### DIFF
--- a/.github/workflows/build-and-push-image-build.yml
+++ b/.github/workflows/build-and-push-image-build.yml
@@ -29,7 +29,7 @@ jobs:
     uses: access-nri/workflows/.github/workflows/build-and-push-image.yml@main
     with:
       container-registry: ghcr.io
-      container-name: access-nri/build-${{ matrix.package }}-${{ matrix.compiler.name }}${{ matrix.compiler.version }}
+      container-name: access-nri/build-${{ matrix.package }}-${{ matrix.compiler.name }}${{ matrix.compiler.version }}-${{ github.event.inputs.spack-packages-version }}
       dockerfile-directory: containers
       dockerfile-name: Dockerfile.build
       build-args: |

--- a/.github/workflows/build-and-push-image-build.yml
+++ b/.github/workflows/build-and-push-image-build.yml
@@ -2,6 +2,12 @@ name: Build and push access-nri/build images
 
 on:
   workflow_dispatch:
+    inputs:
+      spack-packages-version:
+        required: true
+        type: string
+        default: "main"
+        description: "Either a git tag or branch name for the ACCESS-NRI/spack_packages repository, which defaults to the main branch"
 
 jobs:
   build-and-push-image:
@@ -28,7 +34,7 @@ jobs:
       dockerfile-name: Dockerfile.build
       build-args: |
         # TODO: Probably shouldn't hard code base image path
-        "BASE_IMAGE=ghcr.io/access-nri/base-spack:latest"
+        "BASE_IMAGE=ghcr.io/access-nri/base-spack-${{ github.event.inputs.spack-packages-version }}:latest"
         "PACKAGE=${{ matrix.package }}"
         "COMPILER_NAME=${{ matrix.compiler.name}}"
         "COMPILER_PACKAGE=${{ matrix.compiler.package}}"

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -18,6 +18,11 @@ on:
       compiler-version:
         required: true
         type: string
+      spack-packages-version:
+        required: false
+        type: string
+        description: Either a git tag or branch name for the ACCESS-NRI/spack_packages repository, which defaults to the main branch
+        default: main
 
 jobs:
   build:
@@ -27,7 +32,7 @@ jobs:
       packages: read
 
     container:
-      image: ${{ inputs.container-registry }}/${{ inputs.container-name }}:latest
+      image: ${{ inputs.container-registry }}/${{ inputs.container-name }}-${{ inputs.spack-packages-version }}:latest
       credentials:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Using Github CLI:
 
 ```
 gh workflow run build-and-push-image-base-spack.yml
+gh workflow run build-and-push-image-base-spack.yml -f spack-packages-version=v1.0.1
 gh workflow run build-and-push-image-build.yml
 ```
 
@@ -34,6 +35,7 @@ Inputs:
 * `package-name`: The name of the spack package to be built (e.g. `access.nri.oasis3-mct`)
 * `compiler-name`: The name of the compiler to use
 * `compiler-version`: The version of the compiler to use
+* `spack-packages-version`: Optional, defaults to `main`. The git tag or branch for the `ACCESS-NRI/spack_packages` repository. 
 
 ### Usage
 To use, modify the following .yml file and add to your target repository in the `.github/workflows/` directory:
@@ -59,6 +61,7 @@ jobs:
       package-name: [your package name]
       compiler-name: intel
       compiler-version: 2021.1.2
+      spack-packages-version: main # this defaults to main
     permissions:
       packages: read
 ```

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ jobs:
       package-name: [your package name]
       compiler-name: intel
       compiler-version: 2021.1.2
-      spack-packages-version: main # this defaults to main
+      spack-packages-version: main # this doesn't need to be specified, defaults to main
     permissions:
       packages: read
 ```


### PR DESCRIPTION
#6  was re-opened to accommodate some more required features (see https://github.com/ACCESS-NRI/build-ci/issues/6#issuecomment-1633570952) - namely, the ability to pick a spack_packages version from the model version of the workflow. 

This would mean that the built package would be of the form `build-<model>-<compiler><compiler version>-<spack_packages version>:latest`. For example: `built-oasis3-mct-intel2021.1.2-main`. 

Should close #6 