### PR TITLE
13 add cice5

### DIFF
--- a/.github/workflows/build-and-push-image-build.yml
+++ b/.github/workflows/build-and-push-image-build.yml
@@ -16,7 +16,7 @@ jobs:
         package: [
           "oasis3-mct",
           "libaccessom2",
-          "access-om3",
+          #"access-om3",
           "mom5",
           "cice5",
         ]

--- a/.github/workflows/build-and-push-image-build.yml
+++ b/.github/workflows/build-and-push-image-build.yml
@@ -16,7 +16,7 @@ jobs:
         package: [
           "oasis3-mct",
           "libaccessom2",
-          #"access-om3",
+          "access-om3",
           "mom5",
           "cice5",
         ]

--- a/.github/workflows/build-and-push-image-build.yml
+++ b/.github/workflows/build-and-push-image-build.yml
@@ -12,6 +12,7 @@ jobs:
           "libaccessom2",
           "access-om3",
           "mom5",
+          "cice5",
         ]
         compiler: [
           {


### PR DESCRIPTION
Although issues with dependencies/variants going to slack 0.20.1, this is just adding CICE5 to the base image.