### PR TITLE
Added appropriate permissions for base-spack workflow call

### DIFF
--- a/.github/workflows/notified-of-spack-packages-update.yml
+++ b/.github/workflows/notified-of-spack-packages-update.yml
@@ -17,6 +17,9 @@ jobs:
     uses: access-nri/workflows/.github/workflows/build-and-push-image-base-spack.yml@main
     with: 
       spack-packages-version: ${{ github.event.inputs.spack-packages-version }}
+    permissions:
+      contents: read
+      packages: write
 
   generate-matrix:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The build was failing with
> he workflow is not valid. .github/workflows/notified-of-spack-packages-update.yml (Line: 16, Col: 3): Error calling workflow 'access-nri/workflows/.github/workflows/build-and-push-image-base-spack.yml@main'. The nested job 'build-and-push-image' is requesting 'packages: write', but is only allowed 'packages: read'.

Granting explicit permissions should fix this.