### PR TITLE
matrix_generation and workflow fixes

### DIFF
--- a/.github/workflows/notified-of-spack-packages-update.yml
+++ b/.github/workflows/notified-of-spack-packages-update.yml
@@ -36,7 +36,6 @@ jobs:
         run: python ./util/matrix_generation.py ${{ github.event.inputs.packages }}
 
   update-image-builds:
-    runs-on: ubuntu-latest
     needs:
       - update-spack-base-image
       - generate-matrix
@@ -44,21 +43,20 @@ jobs:
       matrix: 
         package: ${{ fromJson(needs.generate-matrix.outputs.packages) }}
         compiler: ${{ fromJson(needs.generate-matrix.outputs.compilers) }}
-    steps:
-      - name: Build model image
-        uses: ./.github/workflows/build-and-push-image.yml@main
-        with:
-          container-registry: ghcr.io
-          container-name: access-nri/build-${{ matrix.package }}-${{ matrix.compiler.name }}${{ matrix.compiler.version }}-${{ github.event.inputs.spack-packages-version }}
-          dockerfile-directory: containers
-          dockerfile-name: Dockerfile.build
-          build-args: |
-            # TODO: Probably shouldn't hard code base image path
-            "BASE_IMAGE=ghcr.io/access-nri/base-spack-${{ github.event.inputs.spack-packages-version }}:latest"
-            "PACKAGE=${{ matrix.package }}"
-            "COMPILER_NAME=${{ matrix.compiler.name}}"
-            "COMPILER_PACKAGE=${{ matrix.compiler.package}}"
-            "COMPILER_VERSION=${{ matrix.compiler.version}}"
+
+    uses: access-nri/workflows/.github/workflows/build-and-push-image.yml@main
+    with:
+      container-registry: ghcr.io
+      container-name: access-nri/build-${{ matrix.package }}-${{ matrix.compiler.name }}${{ matrix.compiler.version }}-${{ github.event.inputs.spack-packages-version }}
+      dockerfile-directory: containers
+      dockerfile-name: Dockerfile.build
+      build-args: |
+        # TODO: Probably shouldn't hard code base image path
+        "BASE_IMAGE=ghcr.io/access-nri/base-spack-${{ github.event.inputs.spack-packages-version }}:latest"
+        "PACKAGE=${{ matrix.package }}"
+        "COMPILER_NAME=${{ matrix.compiler.name}}"
+        "COMPILER_PACKAGE=${{ matrix.compiler.package}}"
+        "COMPILER_VERSION=${{ matrix.compiler.version}}"
     permissions: 
       contents: read
       packages: write

--- a/util/matrix_generation.py
+++ b/util/matrix_generation.py
@@ -34,12 +34,16 @@ def generate_matrix(
                     packages.update(package_mapping)
                     print(f"packages is now {packages}\n")
                     break
+            # reset the file pointer to the beginning of the file
+            file.seek(0)
 
     # send this to the special env var that handles output in github actions
     # turning the set of packages into a list and then into a json object
     with open(os.environ["GITHUB_OUTPUT"], "a") as out:
         print(f"packages={json.dumps(list(packages))}", file=out)
         print(f"compilers={json.dumps(compilers)}", file=out)
+
+    print(json.dumps(list(packages)))
 
     return packages
 

--- a/util/test_matrix_generation.py
+++ b/util/test_matrix_generation.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 from matrix_generation import generate_matrix
 
+
 @pytest.fixture(autouse=True)
 def mock_github_output_env_var():
     with mock.patch.dict(os.environ, {"GITHUB_OUTPUT": "/dev/null"}):
@@ -52,3 +53,6 @@ class TestMatrixGeneration:
             "cice5",
             "mom5",
         }
+
+    def test_mix_of_unknown_and_existing_deps(self):
+        assert generate_matrix(["access-om2", "cice5"]) == {"cice5"}


### PR DESCRIPTION
Testing continues! I am now using my own fork of build-ci to allow for testing without needing to use ACCESS_NRIs own workflows. 
Updates to the workflows reusable workflows, as well as changes to the matrix_generation python script, are in the PR. 