### PR TITLE
Build spack-base directly with build-and-push-image

### DIFF
--- a/.github/workflows/build-and-push-image-base-spack.yml
+++ b/.github/workflows/build-and-push-image-base-spack.yml
@@ -8,13 +8,6 @@ on:
         type: string
         default: "main"
         description: "Either a git tag or branch name for the ACCESS-NRI/spack_packages repository, which defaults to the main branch"
-  workflow_call:
-    inputs:
-      spack-packages-version:
-        required: true
-        type: string
-        default: "main"
-        description: "Either a git tag or branch name for the ACCESS-NRI/spack_packages repository, which defaults to the main branch"
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/notified-of-spack-packages-update.yml
+++ b/.github/workflows/notified-of-spack-packages-update.yml
@@ -14,9 +14,19 @@ on:
 
 jobs:
   update-spack-base-image:
-    uses: access-nri/workflows/.github/workflows/build-and-push-image-base-spack.yml@main
-    with: 
-      spack-packages-version: ${{ github.event.inputs.spack-packages-version }}
+    uses: access-nri/workflows/.github/workflows/build-and-push-image.yml@main
+    with:
+      container-registry: ghcr.io
+      container-name: access-nri/base-spack-${{ github.event.inputs.spack-packages-version }}
+      dockerfile-directory: containers
+      dockerfile-name: Dockerfile.base-spack
+      build-args: "SPACK_PACKAGES_VERSION=${{ github.event.inputs.spack-packages-version }}"
+    secrets:
+      build-secrets: |
+        "S3_ACCESS_KEY_ID=${{ secrets.S3_ACCESS_KEY_ID }}"
+        "S3_ACCESS_KEY_SECRET=${{ secrets.S3_ACCESS_KEY_SECRET }}"
+        "access-nri.priv=${{ secrets.BUILDCACHE_KEY_PRIVATE }}"
+        "access-nri.pub=${{ secrets.BUILDCACHE_KEY_PUBLIC }}"
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Instead of inheriting secrets across reusable workflows (namely, build-and-push-image-base-spack.yml), just pass the secrets directly to build-and-push-image.yml. 