### PR TITLE
9 env based single model dockerfile

### DIFF
--- a/.github/workflows/build-and-push-image-build.yml
+++ b/.github/workflows/build-and-push-image-build.yml
@@ -55,36 +55,18 @@ jobs:
             version: "2021.1.2",
           },
         ]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Build and push dependency image
-        id: dependency-image
-        uses: access-nri/build-ci/.github/workflows/build-and-push-image.yml@main
-        with:
-          container-registry: ghcr.io
-          container-name: access-nri/build-${{ matrix.package }}-${{ matrix.compiler.name }}${{ matrix.compiler.version }}-${{ github.event.inputs.spack-packages-version }}
-          dockerfile-directory: containers
-          dockerfile-name: Dockerfile.build
-          build-args: |
-            # TODO: Probably shouldn't hard code base image path
-            "BASE_IMAGE=ghcr.io/access-nri/base-spack-${{ github.event.inputs.spack-packages-version }}:latest"
-            "PACKAGE=${{ matrix.package }}"
-            "COMPILER_NAME=${{ matrix.compiler.name}}"
-            "COMPILER_PACKAGE=${{ matrix.compiler.package}}"
-            "COMPILER_VERSION=${{ matrix.compiler.version}}"
 
-      - name: Get spack environment files from dependency image
-        id: spackenv
-        run: docker run --rm ${{ steps.dependency-image.outputs.id }} -v environment:/opt/spack/var/spack/environments/${{matrix.package}}:ro
-
-      - name: Publish image and environment as a release
-        uses: actions/create-release@v1.12.0
-        with: 
-          artifacts: "./environment/spack.yaml,./environment/spack.lock"
-          tag: "test"
-
-    permissions:
-      contents: read
-      packages: write
-  
-  
+    uses: access-nri/build-ci/.github/workflows/build-and-push-spack-release@main
+    with:
+      container-registry: ghcr.io
+      container-name: access-nri/build-${{ matrix.package }}-${{ matrix.compiler.name }}${{ matrix.compiler.version }}-${{ github.event.inputs.spack-packages-version }}
+      dockerfile-directory: containers
+      dockerfile-name: Dockerfile.build
+      package-name: ${{ matrix.package }}
+      build-args: |
+        # TODO: Probably shouldn't hard code base image path
+        "BASE_IMAGE=ghcr.io/access-nri/base-spack-${{ github.event.inputs.spack-packages-version }}:latest"
+        "PACKAGE=${{ matrix.package }}"
+        "COMPILER_NAME=${{ matrix.compiler.name}}"
+        "COMPILER_PACKAGE=${{ matrix.compiler.package}}"
+        "COMPILER_VERSION=${{ matrix.compiler.version}}"

--- a/.github/workflows/build-and-push-image-build.yml
+++ b/.github/workflows/build-and-push-image-build.yml
@@ -55,19 +55,36 @@ jobs:
             version: "2021.1.2",
           },
         ]
-    uses: access-nri/build-ci/.github/workflows/build-and-push-image.yml@main
-    with:
-      container-registry: ghcr.io
-      container-name: access-nri/build-${{ matrix.package }}-${{ matrix.compiler.name }}${{ matrix.compiler.version }}-${{ github.event.inputs.spack-packages-version }}
-      dockerfile-directory: containers
-      dockerfile-name: Dockerfile.build
-      build-args: |
-        # TODO: Probably shouldn't hard code base image path
-        "BASE_IMAGE=ghcr.io/access-nri/base-spack-${{ github.event.inputs.spack-packages-version }}:latest"
-        "PACKAGE=${{ matrix.package }}"
-        "COMPILER_NAME=${{ matrix.compiler.name}}"
-        "COMPILER_PACKAGE=${{ matrix.compiler.package}}"
-        "COMPILER_VERSION=${{ matrix.compiler.version}}"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build and push dependency image
+        id: dependency-image
+        uses: access-nri/build-ci/.github/workflows/build-and-push-image.yml@main
+        with:
+          container-registry: ghcr.io
+          container-name: access-nri/build-${{ matrix.package }}-${{ matrix.compiler.name }}${{ matrix.compiler.version }}-${{ github.event.inputs.spack-packages-version }}
+          dockerfile-directory: containers
+          dockerfile-name: Dockerfile.build
+          build-args: |
+            # TODO: Probably shouldn't hard code base image path
+            "BASE_IMAGE=ghcr.io/access-nri/base-spack-${{ github.event.inputs.spack-packages-version }}:latest"
+            "PACKAGE=${{ matrix.package }}"
+            "COMPILER_NAME=${{ matrix.compiler.name}}"
+            "COMPILER_PACKAGE=${{ matrix.compiler.package}}"
+            "COMPILER_VERSION=${{ matrix.compiler.version}}"
+
+      - name: Get spack environment files from dependency image
+        id: spackenv
+        run: docker run --rm ${{ steps.dependency-image.outputs.id }} -v environment:/opt/spack/var/spack/environments/${{matrix.package}}:ro
+
+      - name: Publish image and environment as a release
+        uses: actions/create-release@v1.12.0
+        with: 
+          artifacts: "./environment/spack.yaml,./environment/spack.lock"
+          tag: "test"
+
     permissions:
       contents: read
       packages: write
+  
+  

--- a/.github/workflows/build-and-push-spack-release.yml
+++ b/.github/workflows/build-and-push-spack-release.yml
@@ -1,0 +1,87 @@
+name: Build and Push Image as Spack Release
+on:
+  workflow_call:
+    inputs:
+      container-registry:
+        required: true
+        type: string
+      container-name:
+        required: true
+        type: string
+      dockerfile-directory:
+        required: true
+        type: string
+      dockerfile-name:
+        required: true
+        type: string
+      build-args:
+        required: false
+        type: string
+        default: ""
+      package-name:
+        required: true
+        type: string
+    secrets:
+      build-secrets:
+        required: false
+jobs:
+  build-and-push-image-as-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Buildx is currently required to use a subdirectory w/ build-push-action
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Log in to container registry
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ inputs.container-registry }}
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: ${{ inputs.container-registry }}/${{ inputs.container-name }}
+        flavor: |
+          latest=true
+
+    - name: Build Docker image
+      id: build-push-image
+      uses: docker/build-push-action@v3
+      with:
+        context: "{{defaultContext}}:${{ inputs.dockerfile-directory }}"
+        build-args: ${{ inputs.build-args }}
+        secrets: ${{ secrets.build-secrets }}
+        file: ${{ inputs.dockerfile-name }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        load: true
+    
+    - name: Get Spack Environment Info From Docker Image
+      id: spackenv
+      run: docker run --rm ${{ steps.build-push-image.outputs.imageid }} -v environment:/opt/spack/var/spack/environments/${{ inputs.package-name }}
+
+    - name: Push Docker Image As Package
+      uses: docker/build-push-action@v3
+      with: 
+        context: "{{defaultContext}}:${{ inputs.dockerfile-directory }}"
+        build-args: ${{ inputs.build-args }}
+        secrets: ${{ secrets.build-secrets }}
+        file: ${{ inputs.dockerfile-name }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        push: true
+
+    - name: Push Spack Env as Release
+      uses: ncipollo/release-action@v1.12.0
+      with:
+        artifacts: "environment/spack.*"

--- a/containers/Dockerfile.base-spack
+++ b/containers/Dockerfile.base-spack
@@ -3,20 +3,22 @@ FROM rockylinux:8.7
 SHELL ["/bin/bash", "-c"]
 
 ENV SPACK_ROOT=/opt/spack
-ENV SPACK_PACKAGES_ROOT=/opt/spack_packages
+ENV SPACK_PACKAGES_REPO_ROOT=/opt/spack_packages
 ENV GNUPGHOME=$SPACK_ROOT/opt/spack/gpg
 
-ARG SPACK_PACKAGES_VERSION
+ARG SPACK_PACKAGES_REPO_VERSION
 
-RUN dnf -y group install "Development Tools"
-
-RUN dnf -y install \
+# csh currently required for some build scripts e.g. MOM5
+RUN dnf -y group install "Development Tools" \
+ && dnf -y install \
+    csh \
     gcc-gfortran \
     git \
+    jq \
     python3 \
     python3-pip \
-    # csh currently required for some build scripts e.g. MOM5
-    csh
+ && dnf clean all \
+ && rm -rf /var/cache/yum
 
 # Install spack
 RUN git clone -c feature.manyFiles=true https://github.com/spack/spack.git $SPACK_ROOT --branch v0.20.1 --single-branch --depth=1
@@ -40,13 +42,13 @@ SHELL ["docker-shell"]
 RUN spack bootstrap now
 
 # Set up ACCESS Spack package repo
-RUN git clone -b ${SPACK_PACKAGES_VERSION} https://github.com/ACCESS-NRI/spack_packages.git ${SPACK_PACKAGES_ROOT}
+RUN git clone --depth=1 -b ${SPACK_PACKAGES_REPO_VERSION} https://github.com/ACCESS-NRI/spack_packages.git ${SPACK_PACKAGES_REPO_ROOT}
 COPY repos.yaml $SPACK_ROOT/etc/spack/repos.yaml
 
 # TODO
 # Think about setting up spack S3 build cache for CI here
 # Set up ACCESS Spack buildcache
-RUN pip3 install boto3
+RUN pip3 install --no-cache-dir boto3
 RUN spack gpg init
 
 # Add buildcache mirror

--- a/containers/Dockerfile.build
+++ b/containers/Dockerfile.build
@@ -13,18 +13,14 @@ ARG COMPILER_VERSION
 # Use Spack shell environment for subsequent RUN steps
 SHELL ["docker-shell"]
 
-# Install required compiler
-RUN spack -d install ${COMPILER_PACKAGE}@${COMPILER_VERSION}
-
-# Load required compiler and generate site-wide compilers.yaml
-RUN spack load ${COMPILER_PACKAGE}@${COMPILER_VERSION} && \
-  spack compiler find --scope site
-
-# Build and install package dependencies
-RUN spack -d install --only dependencies ${PACKAGE}%${COMPILER_NAME}@${COMPILER_VERSION}
+# create environment for package, install and load compiler, install only package dependencies 
+RUN spack env create ${PACKAGE} \ 
+ && spack env activate ${PACKAGE} \
+ && spack -d install --fail-fast --add ${COMPILER_PACKAGE}@${COMPILER_VERSION} \
+ && spack load ${COMPILER_PACKAGE}@${COMPILER_VERSION} \
+ && spack compiler find --scope env:${PACKAGE} \
+ && spack -d install --fail-fast --add --only dependencies ${PACKAGE}%${COMPILER_NAME}@${COMPILER_VERSION} \
+ && spack gc -y
 
 # Push any uncached binaries to buildcache
-# `spack find --json | jq .[].name`
-# This returns all currently installed spec names
-RUN dnf -y install jq
 RUN spack -d buildcache create -a -m s3_buildcache `spack find --json | jq --raw-output .[].name`


### PR DESCRIPTION
Dependency images created will now be done inside an environment, and push the `spack.yaml` and `spack.lock` files as a release of build-ci. 

Should close #9 !