### PR TITLE
Removed setting of spack PATH as it is already done later

### DIFF
--- a/containers/Dockerfile.base-spack
+++ b/containers/Dockerfile.base-spack
@@ -14,7 +14,6 @@ LABEL au.org.access-nri.ci.spack-repo-version ${SPACK_REPO_VERSION}
 
 # Install spack
 RUN git clone -c feature.manyFiles=true https://github.com/spack/spack.git $SPACK_ROOT --branch ${SPACK_REPO_VERSION} --single-branch --depth=1
-ENV PATH="$SPACK_ROOT/bin:$PATH"
 
 # Enables setting Spack setup type via SHELL command
 # docker-shell:      Use for build RUN steps


### PR DESCRIPTION
Small optimization - the spack environment is already set up as an entrypoint to the Dockerfile.

Should close #51 !