### PR TITLE
Do not install group "Development Tools", select individual packages

### DIFF
--- a/containers/Dockerfile.base-os
+++ b/containers/Dockerfile.base-os
@@ -12,6 +12,9 @@ RUN dnf update -y \
     bzip2 \
     csh \
     flex \
+    curl \
+    file \
+    findutils \
     gcc \
     gcc-c++ \
     gcc-gfortran \
@@ -19,6 +22,10 @@ RUN dnf update -y \
     glibc-devel \
     jq \
     libtool \
+    gnupg2 \
+    hg \
+    hostname \
+    iproute \
     make \
     patch \
     patchutils \
@@ -27,7 +34,11 @@ RUN dnf update -y \
     pkgconf-pkg-config \
     python3 \
     python3-pip \
+    python3-setuptools \
+    svn \
+    unzip \
     xz \
+    zstd \
  && rm -rf /var/cache/dnf \
  && dnf clean all
 

--- a/containers/Dockerfile.base-os
+++ b/containers/Dockerfile.base-os
@@ -4,14 +4,30 @@ FROM rockylinux:8.8
 
 # csh currently required for some build scripts e.g. MOM5
 RUN dnf update -y \
- && dnf -y group install "Development Tools" \
  && dnf -y install \
+    autoconf \
+    automake \
+    binutils \
+    bison \
+    bzip2 \
+    csh \
+    flex \
+    gcc \
+    gcc-c++ \
     gcc-gfortran \
     git \
+    glibc-devel \
     jq \
+    libtool \
+    make \
+    patch \
+    patchutils \
+    pkgconf \
+    pkgconf-m4 \
+    pkgconf-pkg-config \
     python3 \
     python3-pip \
-    csh \
+    xz \
  && rm -rf /var/cache/dnf \
  && dnf clean all
 


### PR DESCRIPTION
```
Group: Development Tools
 Description: A basic development environment.
 Mandatory Packages:
   autoconf
   automake
   binutils
   bison
   flex
   gcc
   gcc-c++
   gdb
   glibc-devel
   libtool
   make
   pkgconf
   pkgconf-m4
   pkgconf-pkg-config
   redhat-rpm-config
   rpm-build
   rpm-sign
   strace
 Default Packages:
   asciidoc
   byacc
   ctags
   diffstat
   elfutils-libelf-devel
   git
   intltool
   jna
   ltrace
   patchutils
   perl-Fedora-VSP
   perl-Sys-Syslog
   perl-generators
   pesign
   source-highlight
   systemtap
   valgrind
   valgrind-devel
 Optional Packages:
   cmake
   expect
   rpmdevtools
   rpmlint
```