### PR TITLE
Move boto3 install out of Dockerfile.base-os and into Dockerfile.base-spack

### DIFF
--- a/containers/Dockerfile.base-os
+++ b/containers/Dockerfile.base-os
@@ -41,5 +41,3 @@ RUN dnf update -y \
     zstd \
  && rm -rf /var/cache/dnf \
  && dnf clean all
-
-RUN pip3 install --no-cache-dir boto3==1.23.10

--- a/containers/Dockerfile.base-spack
+++ b/containers/Dockerfile.base-spack
@@ -40,6 +40,7 @@ COPY repos.yaml $SPACK_ROOT/etc/spack/repos.yaml
 # TODO
 # Think about setting up spack S3 build cache for CI here
 # Set up ACCESS Spack buildcache
+RUN pip3 install --no-cache-dir boto3==1.23.10
 RUN spack gpg init
 
 # Add buildcache mirror


### PR DESCRIPTION
The dev Dockerfile doesn't need boto3.