### PR TITLE
gave image pipeline the appropriate packages:write permissions

### DIFF
--- a/.github/workflows/build-and-push-image-build.yml
+++ b/.github/workflows/build-and-push-image-build.yml
@@ -54,3 +54,6 @@ jobs:
       compiler-package: ${{ matrix.compiler.package }}
       compiler-version: ${{ matrix.compiler.version }}
       model: ${{ matrix.model }}
+    permissions:
+      contents: read
+      packages: write


### PR DESCRIPTION
The nested workflow is requiring `packages:write` but by default only gets `packages:read` as noted in the logs here: https://github.com/ACCESS-NRI/build-ci/actions/runs/5957828644/workflow

This PR gives the dependency-image-pipeline `contents:read` and `packages:write`. 