### PR TITLE
Parsed matrix as json rather than as a string

### DIFF
--- a/.github/workflows/build-and-push-image-build.yml
+++ b/.github/workflows/build-and-push-image-build.yml
@@ -45,8 +45,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        model: ${{ needs.generate-matrix.outputs.model }}
-        compiler: ${{ needs.generate-matrix.outputs.compiler }}
+        model: ${{ fromJson(needs.generate-matrix.outputs.model) }}
+        compiler: ${{ fromJson(needs.generate-matrix.outputs.compiler) }}
     uses: access-nri/build-ci/.github/workflows/dependency-image-pipeline.yml@main
     with:
       spack-packages-version: ${{ inputs.spack-packages-version }}

--- a/.github/workflows/dependency-image-pipeline.yml
+++ b/.github/workflows/dependency-image-pipeline.yml
@@ -32,10 +32,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Check for existing package
         id: image-exists
+        continue-on-error: true
         run: |
           manifest=$(docker manifest inspect ghcr.io/access-nri/base-spack-${{ inputs.compiler-name }}${{ inputs.compiler-version }}-${{ inputs.spack-packages-version }}:latest)
           if [ "$manifest" != "manifest unknown" ]; then
             echo "check=true" >> $GITHUB_OUTPUT
+            exit 0
           fi
 
   base-spack-image:


### PR DESCRIPTION
Workflow failed to parse the matrix strategy because it was being interpreted as a string rather than a JSON object. Logs here: https://github.com/ACCESS-NRI/build-ci/actions/runs/5957933943 

This PR parses the string from `generate-matrix` as a JSON object. 