### PR TITLE
dependency-image-pipeline now has access to the secrets of the caller workflow

### DIFF
--- a/.github/workflows/build-and-push-image-build.yml
+++ b/.github/workflows/build-and-push-image-build.yml
@@ -54,6 +54,7 @@ jobs:
       compiler-package: ${{ matrix.compiler.package }}
       compiler-version: ${{ matrix.compiler.version }}
       model: ${{ matrix.model }}
+    secrets: inherit
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -25,6 +25,7 @@ on:
 
 jobs:
   build-and-push-image:
+    name: Build and push ${{ inputs.container-name }}
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
Callee workflows must inherit secrets from the caller workflow with `jobs.<job>.secrets.inherit`