### PR TITLE
Modified matrix strategy, pushing model matrix down later in the pipeline

### DIFF
--- a/.github/workflows/build-and-push-image-build.yml
+++ b/.github/workflows/build-and-push-image-build.yml
@@ -22,38 +22,38 @@ jobs:
     name: Generate Matrix of compilers and models
     runs-on: ubuntu-latest
     outputs:
-      model: ${{ steps.get-model.outputs.model }}
-      compiler: ${{ steps.get-compiler.outputs.compiler }}
+      models: ${{ steps.get-model.outputs.models }}
+      compilers: ${{ steps.get-compiler.outputs.compilers }}
     steps:
       - uses: actions/checkout@v3
       - name: Determine correct model(s) to build
         id: get-model
         run: |
           if [[ "${{ inputs.model }}" = "all" ]]; then
-            echo "model=['access-om2', 'access-om3']" >> $GITHUB_OUTPUT
+            echo "models=['access-om2', 'access-om3']" >> $GITHUB_OUTPUT
           else
-            echo "model=['${{ inputs.model }}']" >> $GITHUB_OUTPUT
+            echo "models=['${{ inputs.model }}']" >> $GITHUB_OUTPUT
           fi
       - name: Determine compilers to build
         id: get-compiler
-        run: echo "compiler=$(jq -c . containers/compilers.json)" >> $GITHUB_OUTPUT
+        run: echo "compilers=$(jq -c . containers/compilers.json)" >> $GITHUB_OUTPUT
   
-  dependency-image-pipeline:
-    name: Generate images required for dependency image
+  dependency-image-workflow:
+    name: Create dependency images based on varied compilers and models
     needs:
       - generate-matrix
     strategy:
       fail-fast: false
       matrix:
-        model: ${{ fromJson(needs.generate-matrix.outputs.model) }}
-        compiler: ${{ fromJson(needs.generate-matrix.outputs.compiler) }}
+        compiler: ${{ fromJson(needs.generate-matrix.outputs.compilers) }}
     uses: access-nri/build-ci/.github/workflows/dependency-image-pipeline.yml@main
     with:
-      spack-packages-version: ${{ inputs.spack-packages-version }}
       compiler-name: ${{ matrix.compiler.name }}
       compiler-package: ${{ matrix.compiler.package }}
       compiler-version: ${{ matrix.compiler.version }}
-      model: ${{ matrix.model }}
-    permissions:
-      contents: read
+      spack-packages-version: ${{ inputs.spack-packages-version }}
+      models: ${{ needs.generate-matrix.outputs.models }}
+    permissions: 
       packages: write
+      contents: read
+    secrets: inherit

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -25,6 +25,8 @@ on:
 
 jobs:
   build-and-push-image:
+    name: Build and push ${{ inputs.container-name }}
+
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/dependency-image-pipeline.yml
+++ b/.github/workflows/dependency-image-pipeline.yml
@@ -3,19 +3,19 @@ on:
   workflow_call:
     inputs:
       spack-packages-version:
-        description: Tag associated with the access-nri/spack_packages repo
+        description: the tag/branch of the access-nri/spack_packages repo to use
         type: string
       compiler-name:
-        description: Name of the compiler
+        description: the short name of the compiler
         type: string
       compiler-package:
-        description: Spack package name of the compiler
+        description: the spack-specific package name of the compiler
         type: string
       compiler-version:
-        description: Spack package version of the compiler
+        description: the spack-specific package version of the compiler
         type: string
-      model:
-        description: A model name (eg. access-om2)
+      models:
+        description: a json-string array of all models to be built in a matrix strategy
         type: string
 jobs:
   base-spack-image-check:
@@ -73,12 +73,16 @@ jobs:
     if: always()
     needs:
       - base-spack-image
+    strategy:
+      fail-fast: false
+      matrix:
+        model: ${{ fromJson(inputs.models) }}
     uses: access-nri/build-ci/.github/workflows/build-and-push-image.yml@main
     with:
       container-registry: ghcr.io
-      container-name: access-nri/build-${{ inputs.model}}-${{ inputs.compiler-name }}${{ inputs.compiler-version }}-${{ inputs.spack-packages-version }}
+      container-name: access-nri/build-${{ matrix.model}}-${{ inputs.compiler-name }}${{ inputs.compiler-version }}-${{ inputs.spack-packages-version }}
       dockerfile-directory: containers
-      dockerfile-name: Dockerfile.${{ inputs.model }}
+      dockerfile-name: Dockerfile.${{ matrix.model }}
       build-args: |
         # TODO: Probably shouldn't hard code base image path
         "BASE_IMAGE=ghcr.io/access-nri/base-spack-${{ inputs.compiler-name }}${{ inputs.compiler-version }}-${{ inputs.spack-packages-version }}:latest"


### PR DESCRIPTION
Modified the matrix strategy from a all-at-once 'compiler x model' strategy to a 'first compiler matrix (for base-spack) then model matrix'. This means that multiple 'base-spack' images will not be built in parallel. 

Should close #83 !