### PR TITLE
Added `target` to all other `spack install`s

### DIFF
--- a/containers/Dockerfile.base-spack
+++ b/containers/Dockerfile.base-spack
@@ -13,7 +13,7 @@ ENV SPACK_PACKAGES_REPO_ROOT=/opt/spack_packages
 ENV SPACK_ENV_COMPILER_PACKAGE=${COMPILER_PACKAGE}
 ENV SPACK_ENV_COMPILER_VERSION=${COMPILER_VERSION}
 ENV SPACK_ENV_COMPILER_NAME=${COMPILER_NAME}
-ENV SPACK_ENV_TARGET=x86_64
+ENV SPACK_ENV_ARCH=linux-rocky8-x86_64
 
 LABEL au.org.access-nri.ci.spack-repo-version $SPACK_REPO_VERSION
 LABEL au.org.access-nri.ci.spack-packages-repo-version ${SPACK_PACKAGES_REPO_VERSION}
@@ -67,7 +67,7 @@ RUN --mount=type=secret,id=access-nri.pub \
     spack gpg trust /run/secrets/access-nri.pub
 
 # Set up compilers for this base-spack image 
-RUN spack install ${SPACK_ENV_COMPILER_PACKAGE}@${SPACK_ENV_COMPILER_VERSION} target=${SPACK_ENV_TARGET}
+RUN spack install ${SPACK_ENV_COMPILER_PACKAGE}@${SPACK_ENV_COMPILER_VERSION} arch=${SPACK_ENV_ARCH}
 
 ENTRYPOINT ["/bin/bash", "/opt/spack/share/spack/docker/entrypoint.bash"]
 CMD ["interactive-shell"]

--- a/containers/setup-spack-envs.sh
+++ b/containers/setup-spack-envs.sh
@@ -7,9 +7,9 @@ PACKAGES="$1"
 for PACKAGE in $PACKAGES; do
   spack env create $PACKAGE
   spack env activate $PACKAGE
-  spack -d install -j 4 --add --fail-fast $SPACK_ENV_COMPILER_PACKAGE@$SPACK_ENV_COMPILER_VERSION
-  spack load $SPACK_ENV_COMPILER_PACKAGE@$SPACK_ENV_COMPILER_VERSION
+  spack -d install -j 4 --add --fail-fast $SPACK_ENV_COMPILER_PACKAGE@$SPACK_ENV_COMPILER_VERSION arch=$SPACK_ENV_ARCH
+  spack load $SPACK_ENV_COMPILER_PACKAGE@$SPACK_ENV_COMPILER_VERSION arch=$SPACK_ENV_ARCH
   spack compiler find --scope env:$PACKAGE
-  spack -d install -j 4 --add --only dependencies --fail-fast $PACKAGE%$SPACK_ENV_COMPILER_NAME@$SPACK_ENV_COMPILER_VERSION
+  spack -d install -j 4 --add --only dependencies --fail-fast $PACKAGE%$SPACK_ENV_COMPILER_NAME@$SPACK_ENV_COMPILER_VERSION arch=$SPACK_ENV_ARCH
   spack env deactivate
 done


### PR DESCRIPTION
So spack uses the existing compiler target when in an environment rather than choosing for itself.

Should go some way to completing #86 