### PR TITLE
Make build-package workflow generic

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -2,37 +2,68 @@ name: Build package
 
 on:
   workflow_call:
-    inputs:
-      container-registry:
-        required: true
-        type: string
-      container-name:
-        required: true
-        type: string
-      package-name:
-        required: true
-        type: string
-      compiler-name:
-        required: true
-        type: string
-      compiler-version:
-        required: true
-        type: string
-      spack-packages-version:
-        required: false
-        type: string
-        description: Either a git tag or branch name for the ACCESS-NRI/spack_packages repository, which defaults to the main branch
-        default: main
 
 jobs:
+  setup-spack-packages:
+    name: Get information from spack_packages
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: access-nri/spack_packages
+          ref: main
+          fetch-tags: true
+      - name: Get latest spack_packages tags
+        id: get-version
+        run: echo "version=$(git describe --tags)" >> $GITHUB_OUTPUT
+
+  setup-build-ci:
+    name: Get information from build-ci
+    runs-on: ubuntu-latest
+    outputs:
+      compilers: ${{ steps.get-compilers.outputs.compilers }}
+      model: ${{ steps.get-model.outputs.model }}
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        repository: access-nri/build-ci
+    - name: Get compilers to test
+      id: get-compilers
+      run: echo "compilers=$(jq -c . containers/compilers.json)" >> $GITHUB_OUTPUT
+    - name: Get model to test
+      id: get-model
+      # model-components are associated with an overarching model (for example, cice5 is associated with access-om2), this uses models.json to find the associated model
+      run: echo "model=$(jq -c 'to_entries[] | select(.value | contains(["${{ github.event.repository.name }}"])) | .key' containers/models.json)" >> $GITHUB_OUTPUT
+  
+  setup-model:
+    name: Get information from ${{ github.repository }}
+    runs-on: ubuntu-latest
+    outputs:
+      package-name: ${{ steps.get-package-name.outputs.package }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get package name
+        id: get-package-name
+        # for the cases where the repo name is in uppercase but the package name is lowercase (eg. access-nri/MOM5)
+        run: echo "package=$(echo ${{ github.event.repository.name }} | tr [:upper:] [:lower:])" >> $GITHUB_OUTPUT
+      
   build:
     runs-on: ubuntu-latest
-
+    needs:
+      - setup-spack-packages
+      - setup-build-ci
+      - setup-model
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: ${{ fromJson(needs.setup-build-ci.outputs.compilers) }}
     permissions:
       packages: read
 
     container:
-      image: ${{ inputs.container-registry }}/${{ inputs.container-name }}-${{ inputs.spack-packages-version }}:latest
+      image: ghcr.io/build-${{ needs.setup-build-ci.outputs.model }}-${{ matrix.compiler.name }}${{ matrix.compiler.version }}-${{ needs.setup-spack-packages.outputs.version }}:latest
       credentials:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -47,28 +78,28 @@ jobs:
         fi
     
     - name: Activate environment
-      run: spack env activate ${{ inputs.package-name }}
+      run: spack env activate ${{ needs.setup-model.outputs.package-name }}
     
     - name: Build package via spack
-      run: spack -d install --add --only package --fail-fast --no-checksum ${{ inputs.package-name }}@=$GH_REF%${{ inputs.compiler-name }}@${{ inputs.compiler-version }}
+      run: spack -d install --add --only package --fail-fast --no-checksum ${{ needs.setup-model.outputs.package-name }}@=$GH_REF%${{ matrix.compiler.name }}@${{ matrix.compiler.version }}
     
     - name: Generate lockfile
       run: |
-        cd $SPACK_ROOT/var/spack/environments/${{ inputs.package-name }}
-        cp spack.lock ${{ inputs.package-name }}.original.spack.lock
+        cd $SPACK_ROOT/var/spack/environments/${{ needs.setup-model.outputs.package-name }}
+        cp spack.lock ${{ needs.setup-model.outputs.package-name }}.original.spack.lock
 
     - name: Generate force-concretized lockfile
       if: failure()
       run: |
-        cd $SPACK_ROOT/var/spack/environments/${{ inputs.package-name }}
+        cd $SPACK_ROOT/var/spack/environments/${{ needs.setup-model.outputs.package-name }}
         spack -d concretize --force
-        cp spack.lock ${{ inputs.package-name }}.force.spack.lock
+        cp spack.lock ${{ needs.setup-model.outputs.package-name }}.force.spack.lock
 
     - name: Upload lockfiles
       uses: actions/upload-artifact@v3
       with: 
         name: lockfile-output
-        path: $SPACK_ROOT/var/spack/environments/${{ inputs.package-name }}/${{ inputs.package-name }}.*.spack.lock
+        path: $SPACK_ROOT/var/spack/environments/${{ needs.setup-model.outputs.package-name }}/${{ needs.setup-model.outputs.package-name }}.*.spack.lock
         
 
     # Install and launch interactive debugging on build failure

--- a/containers/models.json
+++ b/containers/models.json
@@ -1,0 +1,4 @@
+{
+    "access-om2": ["libaccessom2", "mom5", "cice5", "oasis3-mct"],
+    "access-om3": ["access-om3"]
+}


### PR DESCRIPTION
Most of the information in the model CI can be inferred from the model repository itself, or the `build-ci` repo.  For example: https://github.com/ACCESS-NRI/MOM5/blob/master/.github/workflows/test-build.yml contains information on the package name and compilers, which can be determined from the repository name and `build-ci/containers/compilers.json` respectively. 

This PR removes the inputs from the build-package reusable workflow and infers them in a `setup` job instead, which will allow all models to use the exact same workflow file. If they can all use the same workflow file, then we can create a starter workflow for any future models as well (provided there is a `.github` repo at the root of the organisation that specifies one).

References #91 (and will close it once all models implement the new generic build-packages) 