### PR TITLE
base-spack: install the compiler earlier

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ jobs:
     uses: access-nri/workflows/.github/workflows/build-package.yml@main
     with:
       container-registry: ghcr.io
-      container-name: access-nri/build-${{ github.event.repository.name }}-intel2021.1.2
+      container-name: access-nri/build-${{ github.event.repository.name }}-intel2021.2.0
       package-name: [your package name]
       compiler-name: intel
-      compiler-version: 2021.1.2
+      compiler-version: 2021.2.0
       spack-packages-version: main # this doesn't need to be specified, defaults to main
     permissions:
       packages: read

--- a/containers/Dockerfile.base-spack
+++ b/containers/Dockerfile.base-spack
@@ -56,7 +56,7 @@ ARG SPACK_REPO_VERSION=v0.20.1
 ARG SPACK_PACKAGES_REPO_VERSION=main
 ARG SPACK_ARCH=linux-rocky8-x86_64
 ARG COMPILER_PACKAGE=intel-oneapi-compilers
-ARG COMPILER_VERSION=2021.1.2
+ARG COMPILER_VERSION=2021.2.0
 ARG COMPILER_NAME=intel
 
 ENV SPACK_ROOT=/opt/spack
@@ -95,14 +95,17 @@ RUN ln -s ${SPACK_ROOT}/share/spack/docker/entrypoint.bash \
 # Setup Spack environment for subsequent RUN steps
 SHELL ["docker-shell"]
 
-# Install ACCESS-NRI's spack_packages repo
-RUN git clone  https://github.com/ACCESS-NRI/spack_packages.git ${SPACK_PACKAGES_REPO_ROOT} --branch ${SPACK_PACKAGES_REPO_VERSION}
-
-RUN spack repo add ${SPACK_PACKAGES_REPO_ROOT} && \
-    spack bootstrap now
+# https://spack.readthedocs.io/en/latest/bootstrapping.html
+# Spack is configured to bootstrap its dependencies lazily by default;
+# i.e. the first time they are needed and can’t be found.
 
 # Install compilers
 RUN spack install ${SPACK_ENV_COMPILER_PACKAGE}@${SPACK_ENV_COMPILER_VERSION} arch=${SPACK_ENV_ARCH}
+
+# Install ACCESS-NRI's spack_packages repo
+RUN git clone  https://github.com/ACCESS-NRI/spack_packages.git ${SPACK_PACKAGES_REPO_ROOT} --branch ${SPACK_PACKAGES_REPO_VERSION}
+
+RUN spack repo add ${SPACK_PACKAGES_REPO_ROOT}
 
 
 ################################################################################

--- a/containers/compilers.json
+++ b/containers/compilers.json
@@ -2,6 +2,6 @@
   {
     "name": "intel",
     "package": "intel-oneapi-compilers",
-    "version": "2021.1.2"
+    "version": "2021.2.0"
   }
 ]

--- a/util/build_dockerfile.build.sh
+++ b/util/build_dockerfile.build.sh
@@ -3,7 +3,7 @@ DOCKER_BUILDKIT=1 \
   --build-arg PACKAGE="mom5" \
   --build-arg COMPILER_PACKAGE="intel-oneapi-compilers" \
   --build-arg COMPILER_NAME="intel" \
-  --build-arg COMPILER_VERSION="2021.1.2" \
+  --build-arg COMPILER_VERSION="2021.2.0" \
   --build-arg BASE_IMAGE="base-spack:latest" \
   -f Dockerfile.build \
   -t build \


### PR DESCRIPTION
* Compiler version set to 2021.2.0 because Gadi /apps does not have 2021.1.2.
* Explicit bootstrap not required.
* Clone and add spack_packages last in the base-spack target.
```
$ docker build -f Dockerfile.base-spack -t spack-dev:20230831.1 --target=dev  .
[+] Building 2404.2s (14/14) FINISHED                                           
 => [internal] load build definition from Dockerfile.base-spack            0.0s
 => => transferring dockerfile: 4.78kB                                     0.0s
 => [internal] load .dockerignore                                          0.0s
 => => transferring context: 2B                                            0.0s
 => [internal] load metadata for docker.io/library/rockylinux:8.8          0.0s
 => [base-os 1/2] FROM docker.io/library/rockylinux:8.8                    0.0s
 => CACHED [base-os 2/2] RUN dnf update -y  && dnf -y install     autocon  0.0s
 => CACHED [base-spack 1/6] RUN git clone -c feature.manyFiles=true https  0.0s
 => CACHED [base-spack 2/6] RUN sed -i 's/granularity: microarchitectures  0.0s
 => CACHED [base-spack 3/6] RUN ln -s /opt/spack/share/spack/docker/entry  0.0s
 => [base-spack 4/6] RUN spack install intel-oneapi-compilers@2021.1.2   225.3s
 => [base-spack 5/6] RUN git clone  https://github.com/ACCESS-NRI/spack_p  2.1s
 => [base-spack 6/6] RUN spack repo add /opt/spack_packages                1.0s 
 => [dev 1/2] RUN spack load intel-oneapi-compilers@2021.1.2  && spack co  1.8s 
 => [dev 2/2] RUN spack install cmake%intel@2021.1.2     gmake%intel@2  2151.4s 
 => exporting to image                                                    22.4s 
 => => exporting layers                                                   22.4s 
 => => writing image sha256:f807b52130c064dd57918040157f919e792ee788fc99f  0.0s 
 => => naming to docker.io/library/spack-dev:20230831.1                    0.0s

$ docker images
REPOSITORY           TAG          IMAGE ID       CREATED          SIZE
spack-dev            20230831.1   f807b52130c0   38 minutes ago   6.7GB

$ docker run -it --rm f807b52130c0
[root@5a4002ce3aba /]# spack bootstrap status
Spack v0.20.1 - python@3.6

[PASS] Core Functionalities

[PASS] Binary packages
```