### PR TITLE
Standardized env and arg vars to use curly braces

### DIFF
--- a/containers/Dockerfile.access-om2
+++ b/containers/Dockerfile.access-om2
@@ -3,13 +3,13 @@ FROM ${BASE_IMAGE}
 
 ARG PACKAGE_NAMES="libaccessom2 mom5 cice5 oasis3-mct"
 
-WORKDIR $SPACK_ROOT
+WORKDIR ${SPACK_ROOT}
 
 LABEL au.org.access-nri.ci.packages ${PACKAGE_NAMES}
 LABEL au.org.access-nri.ci.base-spack-image ${BASE_IMAGE}
-LABEL au.org.access-nri.ci.spack-repo-version $SPACK_REPO_VERSION
-LABEL au.org.access-nri.ci.spack-packages-repo-version $SPACK_PACKAGES_REPO_VERSION
-LABEL au.org.access-nri.ci.compiler $SPACK_ENV_COMPILER_PACKAGE@$SPACK_ENV_COMPILER_VERSION
+LABEL au.org.access-nri.ci.spack-repo-version ${SPACK_REPO_VERSION}
+LABEL au.org.access-nri.ci.spack-packages-repo-version ${SPACK_PACKAGES_REPO_VERSION}
+LABEL au.org.access-nri.ci.compiler ${SPACK_ENV_COMPILER_PACKAGE}@${SPACK_ENV_COMPILER_VERSION}
 
 # Use Spack shell environment for subsequent RUN steps
 SHELL ["docker-shell"]
@@ -21,4 +21,4 @@ RUN chmod +x setup-spack-envs.sh \
  && spack gc -y
 
 # Push any uncached binaries to buildcache
-RUN spack -d buildcache create -a -m s3_buildcache `spack find --json | jq --raw-output .[].name`
+RUN spack -d buildcache create -a -m s3_buildcache $(spack find --json | jq --raw-output .[].name)

--- a/containers/Dockerfile.access-om3
+++ b/containers/Dockerfile.access-om3
@@ -3,13 +3,13 @@ FROM ${BASE_IMAGE}
 
 ARG PACKAGE_NAMES="access-om3"
 
-WORKDIR $SPACK_ROOT
+WORKDIR ${SPACK_ROOT}
 
 LABEL au.org.access-nri.ci.packages ${PACKAGE_NAMES}
 LABEL au.org.access-nri.ci.base-spack-image ${BASE_IMAGE}
-LABEL au.org.access-nri.ci.spack-repo-version $SPACK_REPO_VERSION
-LABEL au.org.access-nri.ci.spack-packages-repo-version $SPACK_PACKAGES_REPO_VERSION
-LABEL au.org.access-nri.ci.compiler $SPACK_ENV_COMPILER_PACKAGE@$SPACK_ENV_COMPILER_VERSION
+LABEL au.org.access-nri.ci.spack-repo-version ${SPACK_REPO_VERSION}
+LABEL au.org.access-nri.ci.spack-packages-repo-version ${SPACK_PACKAGES_REPO_VERSION}
+LABEL au.org.access-nri.ci.compiler ${SPACK_ENV_COMPILER_PACKAGE}@${SPACK_ENV_COMPILER_VERSION}
 
 # Use Spack shell environment for subsequent RUN steps
 SHELL ["docker-shell"]
@@ -21,4 +21,4 @@ RUN chmod +x setup-spack-envs.sh \
  && spack gc -y
 
 # Push any uncached binaries to buildcache
-RUN spack -d buildcache create -a -m s3_buildcache `spack find --json | jq --raw-output .[].name`
+RUN spack -d buildcache create -a -m s3_buildcache $(spack find --json | jq --raw-output .[].name)

--- a/containers/Dockerfile.base-spack
+++ b/containers/Dockerfile.base-spack
@@ -119,8 +119,8 @@ RUN spack gpg init
 RUN --mount=type=secret,id=S3_ACCESS_KEY_ID \
     --mount=type=secret,id=S3_ACCESS_KEY_SECRET \
     spack mirror add \
-    --s3-access-key-id `cat /run/secrets/S3_ACCESS_KEY_ID` \
-    --s3-access-key-secret `cat /run/secrets/S3_ACCESS_KEY_SECRET` \
+    --s3-access-key-id $(cat /run/secrets/S3_ACCESS_KEY_ID) \
+    --s3-access-key-secret $(cat /run/secrets/S3_ACCESS_KEY_SECRET) \
     s3_buildcache \
     s3://access-nri-spack-cache
 

--- a/containers/setup-spack-envs.sh
+++ b/containers/setup-spack-envs.sh
@@ -2,14 +2,14 @@
 
 # usage: ./setup-spack-envs <models string>
 
-PACKAGES="$1"
+PACKAGES="${1}"
 
-for PACKAGE in $PACKAGES; do
-  spack env create $PACKAGE
-  spack env activate $PACKAGE
-  spack -d install -j 4 --add --fail-fast $SPACK_ENV_COMPILER_PACKAGE@$SPACK_ENV_COMPILER_VERSION arch=$SPACK_ENV_ARCH
-  spack load $SPACK_ENV_COMPILER_PACKAGE@$SPACK_ENV_COMPILER_VERSION arch=$SPACK_ENV_ARCH
-  spack compiler find --scope env:$PACKAGE
-  spack -d install -j 4 --add --only dependencies --fail-fast $PACKAGE%$SPACK_ENV_COMPILER_NAME@$SPACK_ENV_COMPILER_VERSION arch=$SPACK_ENV_ARCH
+for PACKAGE in ${PACKAGES}; do
+  spack env create ${PACKAGE}
+  spack env activate ${PACKAGE}
+  spack -d install -j 4 --add --fail-fast ${SPACK_ENV_COMPILER_PACKAGE}@${SPACK_ENV_COMPILER_VERSION} arch=${SPACK_ENV_ARCH}
+  spack load ${SPACK_ENV_COMPILER_PACKAGE}@${SPACK_ENV_COMPILER_VERSION} arch=${SPACK_ENV_ARCH}
+  spack compiler find --scope env:${PACKAGE}
+  spack -d install -j 4 --add --only dependencies --fail-fast ${PACKAGE}%${SPACK_ENV_COMPILER_NAME}@${SPACK_ENV_COMPILER_VERSION} arch=${SPACK_ENV_ARCH}
   spack env deactivate
 done


### PR DESCRIPTION
Instead of environment variables looking like `$THIS` they look like `${THIS}` now. Also changed sub-command expansion from backticks to `$(...)` as that is standard.

Should close #89 