### PR TITLE
JSON Schema and JSON Validation CI

### DIFF
--- a/.github/workflows/json-lint.yml
+++ b/.github/workflows/json-lint.yml
@@ -1,0 +1,36 @@
+name: Validate JSON files
+on:
+  pull_request:
+    paths:
+      - '**.json' 
+jobs:
+  setup-validate-json:
+    name: Setup Validate JSON
+    runs-on: ubuntu-latest
+    outputs:
+      json-to-validate: ${{ steps.get-json.outputs.json }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get all schema 
+        id: get-json
+        # this command finds all the filenames with the '.schema.json' extension, removes that extension, then turns them into a json array
+        # an example of this transformation would be: 'compilers.schema.json models.schema.json' -> 'compilers models' -> '["compilers","models"]' 
+        run: echo "json=$(find containers/ -type f -name '*.schema.json' | xargs basename -s .schema.json | jq -Rcn '[inputs]')" >> $GITHUB_OUTPUT
+
+  validate-json:
+    name: Validate JSON
+    runs-on: ubuntu-latest
+    needs:
+      - setup-validate-json
+    strategy:
+      fail-fast: false
+      matrix: 
+        file: ${{ fromJson(needs.setup-validate-json.outputs.json-to-validate) }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.10'
+      - name: Validate files
+        run: jsonschema -i containers/${{ matrix.file }}.json containers/${{ matrix.file }}.schema.json
+

--- a/containers/compilers.schema.json
+++ b/containers/compilers.schema.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Compilers",
+    "description": "A list of compilers that are supported",
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string"
+            },
+            "package": {
+                "type": "string"
+            },
+            "version": {
+                "type": "string"
+            }
+        },
+        "required": [ "name", "package", "version" ],
+        "additionalProperties": false
+    }
+}

--- a/containers/models.schema.json
+++ b/containers/models.schema.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Models",
+    "description": "A list of ACCESS-NRI Models that are supported",
+    "type": "object",
+    "patternProperties": {
+        "^.*$": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        } 
+    }
+}


### PR DESCRIPTION
Added `*.schema.json` files for validation CI. Can be done on CLI with (for example) `jsonchema -i containers/compilers.json containers/compilers.schema.json`. 
Added build-ci CI (how meta!) for json validation. 

Should close #63 !