### PR TITLE
Readme and documentation updates

### DIFF
--- a/.github/documentation.md
+++ b/.github/documentation.md
@@ -1,0 +1,202 @@
+# build-ci Developer Documentation
+
+This documentation is intended to give a rationale for design decisions, and a more in-depth look into the build-ci pipelines.
+
+This repository contains three main pipelines:
+
+* Dependency Image Pipeline: uses `build-and-push-image-build.yml`, `dependency-image-pipeline.yml`, `dependency-image-build.yml` and `build-and-push-image.yml` workflows.
+* Model Test Pipeline: uses `build-package.yml` workflow.
+* JSON Lint Pipeline: uses `json-lint.yml` workflow.
+
+How they are used can be found in the [CI Run Through section](#ci-workflow-run-through).
+
+## Inputs and Outputs
+
+### I/O for Dependency Image Build Pipeline
+
+#### Dependency Image Build Pipeline Inputs
+
+This pipeline has explicit inputs:
+
+* `spack-packages-version`: A tag or branch of the `access-nri/spack_packages` repository. This allows provenance of the build process of models.
+* `model`: a coupled model name (such as `access-om2` or `access-om3`) or `all` if we want to build dependency images for all coupled models defined in `containers/models.json`.
+
+It also indirectly uses:
+
+* `containers/compilers.json`: This is a structure of all the compilers we want to test against.
+* `containers/models.json`: This is a structure of all the coupled models (and their associated model components) that we want to test against.
+* `containers/Dockerfile.*`: uses these Dockerfiles to create the `base-spack` and `dependency` images.
+
+#### Dependency Image Build Pipeline Outputs
+
+* `base-spack` Docker image: Of the form `base-spack-<compiler name><compiler version>-<spack_packages version>:latest`. A docker image that contains a `spack` install, `access-nri/spack_packages` repo at the specified version, and a site-wide compiler for spack to use to build dependencies.
+* `dependency` Docker image: Of the form `build-<coupled model>-<compiler name><compiler version>-<spack_packages version>:latest`: A docker image based on the above `base-spack` image, that contains all the model components dependencies (separated by `spack env`s), but not the models themselves. The models are added on top of the install in a different pipeline, negating the need for a costly install of the dependencies again (in most cases).
+
+### I/O for Model Test Pipeline
+
+#### Model Test Pipeline Inputs
+
+There are no explicit inputs to this workflow. The information required is inferred by the model repository that calls the `build-package.yml` workflow.
+
+However, there are indirect inputs into this pipeline:
+
+* Appropriate `dependency` Docker images of the form: `ghcr.io/access-nri/build-<coupled model>-<compiler name><compiler version>-<spack_packages version>:latest`.
+* `containers/compilers.json`: This is a structure of all the compilers we want to test against.
+* `containers/models.json`: This is a structure of all the coupled models (and their associated model components) that we want to test against.
+
+#### Model Test Pipeline Outputs
+
+* `<env>.original.spack.lock`: A `spack.lock` file from the `spack env` associated with the modified model repository (eg. `mom5`), before the installation of the modified model. If the install succeeds then then this `spack.lock` file was unmodified during the installation and can be used to recreate this `spack env`. This file is uploaded as an artifact.
+* Optionally, a `<env>.force.spack.lock`: If the installation fails (namely, if installing the modified model would change the `spack.lock` file) we force a regeneration of the `spack.lock` file and upload this as an artifact as well.
+
+### I/O for JSON Linter Pipeline
+
+#### Inputs for JSON Linter Pipeline
+
+This pipeline has no explicit inputs.
+
+However, there are indirect inputs into this pipeline:
+
+* `*.json`: All JSON files that need to be validated.
+* `*.schema.json`: All JSON schemas that validate the above `*.json` files.
+
+#### Outputs for JSON Linter Pipeline
+
+There are no outputs from this pipeline (outside of checks).
+
+## CI Workflow Run Through
+
+### Dependency Image Build Pipeline
+
+The rationale for this pipeline is the creation of a model-dependency docker image. This image contains spack, the `spack env`ironments, and the dependencies for the install of a model, but not the model itself. This allows modified models/model components to be 'dropped in' to the dependency image and installed quickly, without needing to install the dependencies again.
+
+As an overview, this workflow, given a `access-nri/spack_packages` repo version and coupled model(s):
+
+* Generates a staggered `compiler x model` matrix based on the `compilers.json` and `models.json`. This allows generation and testing of multiple different compiler and model image combinations in parallel.  
+* Uses an existing `base-spack` docker image (or creates it if it doesn't exist) that contains an install of spack, access-nri/spack_packages and a given compiler.
+* Using the above `base-spack` image, creates a spack-based model-dependency docker image that separates each model (and it's components) into `spack env`s. This has all the dependencies of the model installed, but not the model itself.
+
+#### Pipeline Overview
+
+In the follow example, we have two compilers (`c1, c2`) and two (coupled) models (`m1, m2`).
+
+##### The Beginning (build-and-push-image-build.yml)
+
+This pipeline begins at `build-and-push-image-build.yml`:
+
+```txt
+build-and-push-image-build.yml [compilers c1 c2]
+```
+
+This workflow is responsible for generating the matrix of compilers (from `containers/compilers.json`) and the information necessary for creating a matrix of coupled models for a future matrix (from `models.json`).
+
+Rather than doing the `compiler x model` matrix at the beginning of the workflow, we do the model matrix later. This is because we would be duplicating the creation of the `base-spack` image, which thrashes dockers caching. A more detailed explanation is in [the appendix of this document](#on-the-matrix-strategy-for-the-dependency-image-pipeline).
+
+After the `compiler` matrix is created, we call the `dependency-image-pipeline.yml` workflow on each of the compilers, parallelizing the pipeline like so:
+
+```txt
+build-and-push-image-build.yml [compilers c1 c2]
+    |- [c1] dependency-image-pipeline.yml
+    |- [c2] dependency-image-pipeline.yml 
+```
+
+##### Creation of `base-spack` and setup of dependency image (dependency-image-pipeline.yml)
+
+In this workflow, given the specs for a given compiler, a `spack_packages` version, and a list of models for a future `model` matrix strategy, we seek to:
+
+* Check that a suitable `base-spack` image doesn't already exists. This would be one that has the same compiler and same version of spack_packages.
+* If it doesn't exist, create and push it using the reusable `build-and-push-image.yml` workflow.
+* After those steps, create the aforementioned `model` matrix strategy, running the `dependency-image-build.yml` workflow for each of the models. At this point, the pipeline looks like this:
+
+```txt
+build-and-push-image-build.yml [compilers c1 c2]
+    |- [c1] dependency-image-pipeline.yml
+    |   |- build-and-push-image.yml (base-spack-c1)
+    |   |- dependency-image-build.yml [models m1 m2]
+    |- [c2] dependency-image-pipeline.yml
+        |- build-and-push-image.yml (base-spack-c2)
+        |- dependency-image-build.yml [models m1 m2]
+```
+
+##### Creation of Dependency Image (dependency-image-build.yml)
+
+Finally, with the `base-spack` image created, and the models that need to be built turned into a matrix strategy, we can create the dependency image. At this stage, we have as inputs: a given compiler spec, a `spack_packages` version, and the name of a single coupled model that we want turned into a dependency image. We have all the information necessary for this now.  
+
+In the `dependency-image-build.yml` workflow, we:
+
+* Get the associated model components of our coupled model from the `containers/models.json` file.
+* Build and push the dependency image given the existing `base-spack` image as a base, and the list of model components from the previous job, using the reusable `build-and-push-image.yml` workflow.
+
+This leads to a final pipeline looking like the following:
+
+```txt
+build-and-push-image-build.yml [compilers c1 c2]
+    |- [c1] dependency-image-pipeline.yml
+    |   |- build-and-push-image.yml (base-spack-c1)
+    |   |- dependency-image-build.yml [models m1 m2]
+    |       |- [m1] build-and-push-image.yml (dep-image-c1-m1) 
+    |       |- [m2] build-and-push-image.yml (dep-image-c1-m2) 
+    |- [c2] dependency-image-pipeline.yml 
+    |   |- build-and-push-image.yml (base-spack-c2)
+    |   |- dependency-image-build.yml [models m1 m2]
+    |       |- [m1] build-and-push-image.yml (dep-image-c2-m1) 
+    |       |- [m2] build-and-push-image.yml (dep-image-c2-m2) 
+```
+
+### Model Test Pipeline
+
+This workflow seeks to build upon the Dependency Image Pipeline as explained above by taking an appropriate dependency image and attempting to install a modified (most likely from a PR) model over the top. This allows further testing and runs of a modified model without the excessive overhead of installing dependencies from scratch.
+
+#### Model Test Pipeline Overview
+
+Model repositories that implement the `model-build-test-ci.yml` starter workflow (such as the [access-nri/MOM5](https://github.com/ACCESS-NRI/MOM5/blob/master/.github/workflows/model-build-test-ci.yml) repo) will call `build-ci`s `build-package.yml` workflow.
+
+This workflow begins by inferring the 'appropriate dependency image' based on a number of factors, mostly coming from the name of the dependency image (which is of the form `build-<coupled model>-<compiler name><compiler version>-<spack_packages version>:latest`).
+
+In order to find:
+
+* `spack_packages version`: In the `setup-spack-packages` job, we take the latest tagged version of the `access-nri/spack_packages` repo.
+* `coupled model`: In the `setup-model` and `setup-build-ci` jobs, we use the name of the calling repository (eg. `cice5`) and `build-ci`s `containers/models.json` to infer the overarching `coupled model` name.
+* `compiler name`/`compiler version`: In the `setup-build-ci` job, we use all compilers from the `containers/compilers.json` file. This would mean that another matrix strategy would be in order.
+
+Given those inferences, we would be able to find the appropriate dependency images to install the modified models into.
+
+We then use those containers to upload the original `spack.lock` files (also known as lockfiles) and then attempt to install the modified model in the appropriate `spack env`. If this fails, we force a recreation of the lockfile and upload this one as well, for reference.
+
+### JSON Linter Pipeline
+
+This is a relatively simple pipeline (found in `json-lint.yml`) that looks for `*.schema.json` files in `containers`, matches them up with the associated `*.json` files and makes sure they comply with the given schema.
+
+## Reusable Workflows
+
+### build-and-push-image.yml
+
+`build-and-push-image.yml` is the most used reusable workflow. This workflow builds, caches, and pushes a given Dockerfile to a given container registry. Build args and build secrets can also be added.
+
+## Appendix
+
+### On the matrix strategy for the Dependency Image Pipeline
+
+At first glance, the Dependency Image Pipeline seems needlessly complex. Why do we do a `compiler` matrix then a `model` matrix strategy, instead of a `compiler x model` matrix strategy? This section attempts to explain it.
+
+At it's core, it is about removing duplication of effort and effectively using the cache, rather than thrashing the cache.
+
+Imagine we have a `compiler x model` matrix with 2 compilers `c1, c2` and two models `m1, m2`. The matrix strategy would be:
+
+```txt
+[compiler x model] --- [c1, m1] --- base-spack-c1 image --- dep-c1-m1 image
+                    |- [c1, m2] --- base-spack-c1 image --- dep-c1-m2 image
+                    |- [c2, m1] --- base-spack-c2 image --- dep-c2-m1 image
+                    |- [c2, m2] --- base-spack-c2 image --- dep-c2-m2 image
+```
+
+The two copies of `base-spack-c1` and `base-spack-c2` images are created in parallel, which duplicates effort and makes the cache unusable. Instead, if we stagger the creation of the matrix, as noted below:  
+
+```txt
+[compiler] --- [c1] --- base-spack-c1 image --- [model] --- [m1] --- dep-c1-m1 image
+            |                                            |- [m2] --- dep-c1-m2 image
+            |- [c2] --- base-spack-c2 image --- [model] --- [m1] --- dep-c2-m1 image
+                                                         |- [m2] --- dep-c1-m2 image
+```
+
+We instead only create one copy of `base-spack-c1` and `base-spack-c2`, leveraging the various caches we use.

--- a/.github/documentation.md
+++ b/.github/documentation.md
@@ -78,7 +78,7 @@ As an overview, this workflow, given a `access-nri/spack_packages` repo version 
 
 #### Pipeline Overview
 
-In the follow example, we have two compilers (`c1, c2`) and two (coupled) models (`m1, m2`).
+In the following example, we have two compilers (`c1, c2`) and two (coupled) models (`m1, m2`).
 
 ##### The Beginning (build-and-push-image-build.yml)
 

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -16,7 +16,7 @@ How they are used can be found in the [CI Run Through section](#ci-workflow-run-
 
 #### Inputs
 
-This pipeline has explicit inputs:
+This pipeline has explicit inputs, defined in the [`on.workflow_call.inputs` section](https://github.com/ACCESS-NRI/build-ci/blob/1b998192946c364fb75040e6807e7143c9123527/.github/workflows/dep-image-1-start.yml#L5-L15):
 
 * `spack-packages-version`: A tag or branch of the `access-nri/spack_packages` [repository](https://github.com/ACCESS-NRI/spack_packages). This allows provenance of the build process of models.
 * `model`: a coupled model name (such as `access-om2` or `access-om3`) or `all` if we want to build dependency images for all coupled models defined in `containers/models.json`.
@@ -53,9 +53,9 @@ However, there are indirect inputs into this pipeline:
 
 ### JSON Validator Pipeline
 
-#### Inputs
-
 This workflow finds all the [JSON Schema](https://json-schema.org/) files in the project, i.e. those with the '.schema.json' extension, and then runs [`jsonschema`](https://pypi.org/project/jsonschema/) on the matching json files. e.g. `containers/model.json` is validated against `containers/models.schema.json`.
+
+#### Inputs
 
 This pipeline has no explicit inputs.
 

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -82,7 +82,18 @@ As an overview, this workflow, given a `access-nri/spack_packages` repo version 
 
 #### Pipeline Overview
 
-In the following example, we have two compilers (`c1, c2`) and two (coupled) models (`m1, m2`).
+There will be diagrams that seek to explain the calling and matrix structure of the pipeline, in parts. They will look like this:
+
+```txt
+workflow.yml [component comp1 comp2 comp3]
+  |- [comp1] another-workflow.yml
+  |- [comp2] another-workflow.yml
+  |- [comp3] another-workflow.yml
+```
+
+In the above diagram, the first line means that we initially call `workflow.yml`. Within that workflow, we have a matrix strategy in which we call `another-workflow.yml` with each part of the `component` matrix in parallel (with these components being `comp1`, `comp2` and `comp3`).
+
+In the example we will be using for this pipeline, we have a compiler matrix with two compilers (`c1, c2`) and a model matrix with two (coupled) models (`m1, m2`). 
 
 ##### The Beginning (dep-image-1-start.yml)
 

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -55,6 +55,8 @@ However, there are indirect inputs into this pipeline:
 
 #### Inputs
 
+This workflow finds all the [JSON Schema](https://json-schema.org/) files in the project, i.e. those with the '.schema.json' extension, and then runs [`jsonschema`](https://pypi.org/project/jsonschema/) on the matching json files. e.g. `containers/model.json` is validated against `containers/models.schema.json`.
+
 This pipeline has no explicit inputs.
 
 However, there are indirect inputs into this pipeline:

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -77,7 +77,7 @@ The rationale for this pipeline is the creation of a model-dependency docker ima
 As an overview, this workflow, given a `access-nri/spack_packages` repo version and coupled model(s):
 
 * Generates a staggered `compiler x model` matrix based on the [`compilers.json`](https://github.com/ACCESS-NRI/build-ci/blob/maine/containers/compilers.json) and [`models.json`](https://github.com/ACCESS-NRI/build-ci/blob/main/containers/models.json). This allows generation and testing of multiple different compiler and model image combinations in parallel.  
-* Uses an existing `base-spack` docker image (or creates it if it doesn't exist) that contains an install of spack, access-nri/spack_packages and a given compiler.
+* Uses an existing `base-spack` docker image (or creates it if it doesn't exist) that contains an install of spack, `access-nri/spack_packages` and a given compiler.
 * Using the above `base-spack` image, creates a spack-based model-dependency docker image that separates each model (and it's components) into `spack env`s. This has all the dependencies of the model installed, but not the model itself.
 
 #### Pipeline Overview

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -23,14 +23,16 @@ This pipeline has explicit inputs:
 
 It also indirectly uses:
 
-* `[containers/compilers.json`](https://github.com/ACCESS-NRI/build-ci/blob/main/containers/compilers.json): This is a data structure containing all the compilers we want to test against.
+* [`containers/compilers.json`](https://github.com/ACCESS-NRI/build-ci/blob/main/containers/compilers.json): This is a data structure containing all the compilers we want to test against.
 * [`containers/models.json`](https://github.com/ACCESS-NRI/build-ci/blob/main/containers/models.json): This is a data structure containing all the coupled models (and their associated model components) that we want to test against.
-* [`containers/Dockefile.base-spack`](https://github.com/ACCESS-NRI/build-ci/blob/main/containers/Dockerfile.base-spack), [`containers/Dockerfile.depdency`](https://github.com/ACCESS-NRI/build-ci/blob/main/containers/Dockerfile.dependency) : uses these Dockerfiles to create the `base-spack` and `dependency` images.
+* [`containers/Dockefile.base-spack`](https://github.com/ACCESS-NRI/build-ci/blob/main/containers/Dockerfile.base-spack), [`containers/Dockerfile.dependency`](https://github.com/ACCESS-NRI/build-ci/blob/main/containers/Dockerfile.dependency) : uses these Dockerfiles to create the `base-spack` and `dependency` images.
 
 #### Outputs
+
 This pipeline creates two docker image outputs:
-* `base-spack` Docker image: Of the form `base-spack-<compiler name><compiler version>-<spack_packages version>:latest`. A docker image that contains a `spack` install, `access-nri/spack_packages` repo at the specified version, and a site-wide compiler for spack to use to build dependencies.
-* `dependency` Docker image: Of the form `build-<coupled model>-<compiler name><compiler version>-<spack_packages version>:latest`: A docker image based on the above `base-spack` image, that contains all the model components dependencies (separated by `spack env`s), but not the models themselves. The models are added on top of the install in a different pipeline, negating the need for a costly install of the dependencies again (in most cases).
+
+* `base-spack` Docker image: Of the form `base-spack-<compiler name><compiler version>-<spack_packages version>:latest`. A docker image that contains a `spack` install, `access-nri/spack_packages` repo at the specified version, and a site-wide compiler for spack to use to build dependencies. An example of this package is [`base-spack-intel2021.2.0-main`](https://github.com/ACCESS-NRI/build-ci/pkgs/container/base-spack-intel2021.2.0-main).
+* `dependency` Docker image: Of the form `build-<coupled model>-<compiler name><compiler version>-<spack_packages version>:latest`: A docker image based on the above `base-spack` image, that contains all the model components dependencies (separated by `spack env`s), but not the models themselves. The models are added on top of the install in a different pipeline, negating the need for a costly install of the dependencies again (in most cases). An example of this package is [`build-access-om3-intel2021.2.0-main`](https://github.com/orgs/ACCESS-NRI/packages/container/package/build-access-om3-intel2021.2.0-main).
 
 ### Model Test Pipeline
 
@@ -41,7 +43,7 @@ There are no explicit inputs to this workflow. The information required is infer
 However, there are indirect inputs into this pipeline:
 
 * Appropriate `dependency` Docker images of the form: `ghcr.io/access-nri/build-<coupled model>-<compiler name><compiler version>-<spack_packages version>:latest`.
-* `[containers/compilers.json`](https://github.com/ACCESS-NRI/build-ci/blob/main/containers/compilers.json): This is a data structure containing all the compilers we want to test against.
+* [`containers/compilers.json`](https://github.com/ACCESS-NRI/build-ci/blob/main/containers/compilers.json): This is a data structure containing all the compilers we want to test against.
 * [`containers/models.json`](https://github.com/ACCESS-NRI/build-ci/blob/main/containers/models.json): This is a data structure containing all the coupled models (and their associated model components) that we want to test against.
 
 #### Outputs

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -18,7 +18,7 @@ How they are used can be found in the [CI Run Through section](#ci-workflow-run-
 
 This pipeline has explicit inputs:
 
-* `spack-packages-version`: A tag or branch of the `access-nri/spack_packages` repository. This allows provenance of the build process of models.
+* `spack-packages-version`: A tag or branch of the `access-nri/spack_packages` [repository](https://github.com/ACCESS-NRI/spack_packages). This allows provenance of the build process of models.
 * `model`: a coupled model name (such as `access-om2` or `access-om3`) or `all` if we want to build dependency images for all coupled models defined in `containers/models.json`.
 
 It also indirectly uses:

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -68,7 +68,7 @@ There are no outputs from this pipeline (outside of checks).
 
 ### Dependency Image Build Pipeline
 
-The rationale for this pipeline is the creation of a model-dependency docker image. This image contains spack, the `spack env`ironments, and the dependencies for the install of a model, but not the model itself. This allows modified models/model components to be 'dropped in' to the dependency image and installed quickly, without needing to install the dependencies again.
+The rationale for this pipeline is the creation of a model-dependency docker image. This image contains spack, the `spack env`s, and the dependencies for the install of a model, but not the model itself. This allows modified models/model components to be 'dropped in' to the dependency image and installed quickly, without needing to install the dependencies again.
 
 As an overview, this workflow, given a `access-nri/spack_packages` repo version and coupled model(s):
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,15 @@ This pipeline checks that a given `*.json` file complies with an associated `*.s
 
 ### For Model repositories
 
-If you want to use the Model Test Pipeline (and the model is available in `access-nri/spack_packages` and has an associated entry in `containers/models.json`), go to the repo, then the `Actions` tab, then the `New Workflow` button. You should see a section of starter workflows by ACCESS-NRI. Simply add the `Model Build Test Workflow`, and next time there is a PR on that repo, it will test for installability.
+If you want to use the Model Test Pipeline go to the repo, then the `Actions` tab, then the `New Workflow` button. You should see a section of starter workflows by ACCESS-NRI. Simply add the `Model Build Test Workflow`, and next time there is a PR on that repo, it will test for installability. Note your model must meet the requirements below
 
-### Creation of your own Dependency Images
+#### Requirements
+
+Model must meet these requirements:
+- Be [available as a spack package](https://github.com/ACCESS-NRI/spack_packages/tree/main/packages) in the [`access-nri/spack_packages` repo](https://github.com/ACCESS-NRI/spack_packages)
+- Have an entry in [`containers/models.json`](https://github.com/ACCESS-NRI/build-ci/blob/main/containers/models.json) in this repo
+
+### Create your own Dependency Images
 
 There is an associated `workflow_dispatch` trigger on `build-and-push-image-build.yml` that allows the creation of your own `base-spack` and `dependency` images. Just make sure that the `spack_packages version` tag exists in the `access-nri/spack_packages` repo.
 
@@ -40,4 +46,4 @@ A [Web UI trigger](https://github.com/ACCESS-NRI/build-ci/actions/workflows/buil
 
 ## More information
 
-For more of a dev-focussed look at the CI pipeline, see `README-DEV.md`.
+For more of a dev-focussed look at the CI pipeline, see [`README-DEV.md`](https://github.com/ACCESS-NRI/build-ci/blob/main/README-DEV.md).

--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ A [Web UI trigger](https://github.com/ACCESS-NRI/build-ci/actions/workflows/buil
 
 ## More information
 
-For more of a dev-focussed look at the CI pipeline, see `.github/documentation.md`.
+For more of a dev-focussed look at the CI pipeline, see `README-DEV.md`.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you want to use the Model Test Pipeline (and the model is available in `acces
 
 There is an associated `workflow_dispatch` trigger on `build-and-push-image-build.yml` that allows the creation of your own `base-spack` and `dependency` images. Just make sure that the `spack_packages version` tag exists in the `access-nri/spack_packages` repo.
 
-The Web UI trigger can be [found here](https://github.com/ACCESS-NRI/build-ci/actions/workflows/build-and-push-image-build.yml).
+A [Web UI trigger](https://github.com/ACCESS-NRI/build-ci/actions/workflows/build-and-push-image-build.yml) is available.
 
 ## More information
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This pipeline creates Docker images that contain an install of `spack`, a versio
 
 This allows the install of modified models (and model components) for quick CI testing, rather than having to install an entire dependency tree every time a PR is opened.
 
-These packages are in the [`build-ci` repo](https://github.com/orgs/ACCESS-NRI/packages?tab=packages&q=build-).
+These Dependency Images are in the [`build-ci` repo](https://github.com/orgs/ACCESS-NRI/packages?tab=packages&q=build-).
 
 ### Model Test Pipeline
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ If you want to use the Model Test Pipeline go to the repo, then the `Actions` ta
 #### Requirements
 
 Model must meet these requirements:
+
 - Be [available as a spack package](https://github.com/ACCESS-NRI/spack_packages/tree/main/packages) in the [`access-nri/spack_packages` repo](https://github.com/ACCESS-NRI/spack_packages)
 - Have an entry in [`containers/models.json`](https://github.com/ACCESS-NRI/build-ci/blob/main/containers/models.json) in this repo
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains three overarching CI pipelines:
 
 ### Dependency Image Pipeline
 
-This pipeline creates Docker images that contain an install of `spack`, a version of the `access-nri/spack_packages` repository, and a set of independent `spack env`ironments that contain all the dependencies for all the model components of a coupled model.
+This pipeline creates Docker images that contain an install of `spack`, a version of the `access-nri/spack_packages` [repository](https://github.com/ACCESS-NRI/spack_packages), and a set of independent `spack env`ironments that contain all the dependencies for all the model components of a coupled model.
 
 This allows the install of modified models (and model components) for quick CI testing, rather than having to install an entire dependency tree every time a PR is opened.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This pipeline creates Docker images that contain an install of `spack`, a versio
 
 This allows the install of modified models (and model components) for quick CI testing, rather than having to install an entire dependency tree every time a PR is opened.
 
-If you want to take a look, these packages can be [found here](https://github.com/orgs/ACCESS-NRI/packages?tab=packages&q=build-) in the `build-ci` repo.
+These packages are in the [`build-ci` repo](https://github.com/orgs/ACCESS-NRI/packages?tab=packages&q=build-).
 
 ### Model Test Pipeline
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Model must meet these requirements:
 
 ### Create your own Dependency Images
 
-There is an associated `workflow_dispatch` trigger on `build-and-push-image-build.yml` that allows the creation of your own `base-spack` and `dependency` images. Just make sure that the `spack_packages version` tag exists in the `access-nri/spack_packages` repo.
+There is an associated `workflow_dispatch` trigger on [`dep-image-1-start.yml`](https://github.com/ACCESS-NRI/build-ci/blob/main/.github/workflows/dep-image-1-start.yml) that allows the creation of your own `base-spack` and `dependency` images. Just make sure that the `spack_packages version` tag exists in the `access-nri/spack_packages` repo.
 
 A [Web UI trigger](https://github.com/ACCESS-NRI/build-ci/actions/workflows/build-and-push-image-build.yml) is available.
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ If you want to take a look, these packages can be [found here](https://github.co
 
 This pipeline is called by any model repo that uses the `model-build-test-ci.yml` starter workflow. It uses the images mentioned above to test the installability of modified models (usually created via PRs) quickly.
 
+Examples of this are [access-nri/cice5](https://github.com/ACCESS-NRI/cice5/blob/master/.github/workflows/model-build-test-ci.yml) and [access-nri/mom5](https://github.com/ACCESS-NRI/MOM5/blob/master/.github/workflows/model-build-test-ci.yml)
+
 ### JSON Lint Pipeline
 
 This pipeline checks that a given `*.json` file complies with an associated `*.schema.json` file. Right now it is only being used in the `build-ci` repo.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains three overarching CI pipelines:
 
 ### Dependency Image Pipeline
 
-This pipeline creates Docker images that contain an install of `spack`, a version of the `access-nri/spack_packages` [repository](https://github.com/ACCESS-NRI/spack_packages), and a set of independent `spack env`ironments that contain all the dependencies for all the model components of a coupled model.
+This pipeline creates Docker images that contain an install of `spack`, a version of the `access-nri/spack_packages` [repository](https://github.com/ACCESS-NRI/spack_packages), and a set of independent `spack env`s that contain all the dependencies for all the model components of a coupled model.
 
 This allows the install of modified models (and model components) for quick CI testing, rather than having to install an entire dependency tree every time a PR is opened.
 


### PR DESCRIPTION
With all the changes to the CI pipeline, the documentation has gone out of date. In this PR:
* Update of `README.md` to contain a summarised Overview and Usages 
* Creation of a `README-DEV.md` that contains a pipeline run through that is more useful to developers

Should close #22 !