### PR TITLE
Make JSON validation workflow reusable

### DIFF
--- a/.github/workflows/json-1-validate.yml
+++ b/.github/workflows/json-1-validate.yml
@@ -4,33 +4,8 @@ on:
     paths:
       - '**.json' 
 jobs:
-  setup-validate-json:
-    name: Setup Validate JSON
-    runs-on: ubuntu-latest
-    outputs:
-      json-to-validate: ${{ steps.get-json.outputs.json }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: Get all schema 
-        id: get-json
-        # this command finds all the filenames with the '.schema.json' extension, removes that extension, then turns them into a json array
-        # an example of this transformation would be: 'compilers.schema.json models.schema.json' -> 'compilers models' -> '["compilers","models"]' 
-        run: echo "json=$(find containers/ -type f -name '*.schema.json' | xargs basename -s .schema.json | jq -Rcn '[inputs]')" >> $GITHUB_OUTPUT
-
-  validate-json:
-    name: Validate JSON
-    runs-on: ubuntu-latest
-    needs:
-      - setup-validate-json
-    strategy:
-      fail-fast: false
-      matrix: 
-        file: ${{ fromJson(needs.setup-validate-json.outputs.json-to-validate) }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
-        with:
-          python-version: '3.10'
-      - name: Validate files
-        run: jsonschema -i containers/${{ matrix.file }}.json containers/${{ matrix.file }}.schema.json
-
+  validate:
+    name: Validate
+    uses: access-nri/build-ci/.github/workflows/validate-json.yml@main
+    with:
+      src: "containers"

--- a/.github/workflows/validate-json.yml
+++ b/.github/workflows/validate-json.yml
@@ -1,0 +1,42 @@
+name: Validate JSON
+on:
+  workflow_call:
+    inputs:
+      src:
+        type: string
+        required: false
+        default: "."
+        description: "A directory that contains both the *.json/*.schema.json files (defaults to '.')"
+
+     
+jobs:
+  setup-validate-json:
+    name: Setup Validate JSON
+    runs-on: ubuntu-latest
+    outputs:
+      json-to-validate: ${{ steps.get-json.outputs.json }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get all schema 
+        id: get-json
+        # this command finds all the filenames with the '.schema.json' extension, removes that extension, then turns them into a json array
+        # an example of this transformation would be: 'compilers.schema.json models.schema.json' -> 'compilers models' -> '["compilers","models"]' 
+        run: echo "json=$(find ${{ inputs.src }} -type f -name '*.schema.json' | xargs basename --suffix '.schema.json' | jq --raw-input --null-input --compact-output '[inputs]')" >> $GITHUB_OUTPUT
+
+  validate-json:
+    name: Validate JSON
+    runs-on: ubuntu-latest
+    needs:
+      - setup-validate-json
+    strategy:
+      fail-fast: false
+      matrix: 
+        file: ${{ fromJson(needs.setup-validate-json.outputs.json-to-validate) }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.10'
+      - name: Validate files
+        run: jsonschema --instance ${{ inputs.src }}/${{ matrix.file }}.json ${{ inputs.src }}/${{ matrix.file }}.schema.json
+

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -207,3 +207,7 @@ This is a relatively simple pipeline (found in [`json-1-validate.yml`](https://g
 ### build-docker-image.yml
 
 [`build-docker-image.yml`](https://github.com/ACCESS-NRI/build-ci/blob/main/.github/workflows/build-docker-image.yml) is the most used reusable workflow. This workflow builds, caches, and pushes a given Dockerfile to a given container registry. Build args and build secrets can also be added.
+
+### validate-json.yml
+
+[validate-json.yml](https://github.com/ACCESS-NRI/build-ci/blob/main/.github/workflows/validate-json.yml) is a workflow that searches for `*.schema.json` files, matches them with their associated `*.json` files, and runs a parallel `jsonschema` check over all of the files that it finds. The only input to this workflow is the `src` directory, which is used to discover matching `*.schema.json`/`*.json` pairs. For now, they must be in the same directory. 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository is also responsible for building Docker images used for CI compi
 
 This repository contains three overarching CI pipelines:
 
-### Dependency Image Pipeline
+### Dependency Image Pipeline (dep-image-*)
 
 This pipeline creates Docker images that contain an install of `spack`, a version of the `access-nri/spack_packages` [repository](https://github.com/ACCESS-NRI/spack_packages), and a set of independent `spack env`s that contain all the dependencies for all the model components of a coupled model.
 
@@ -16,15 +16,15 @@ This allows the install of modified models (and model components) for quick CI t
 
 These Dependency Images are in the [`build-ci` repo](https://github.com/orgs/ACCESS-NRI/packages?tab=packages&q=build-).
 
-### Model Test Pipeline
+### Model Test Pipeline (model-*)
 
 This pipeline is called by any model repo that uses the `model-build-test-ci.yml` starter workflow. It uses the images mentioned above to test the installability of modified models (usually created via PRs) quickly.
 
 Examples of this are [access-nri/cice5](https://github.com/ACCESS-NRI/cice5/blob/master/.github/workflows/model-build-test-ci.yml) and [access-nri/mom5](https://github.com/ACCESS-NRI/MOM5/blob/master/.github/workflows/model-build-test-ci.yml)
 
-### JSON Lint Pipeline
+### JSON Lint Pipeline (json-*)
 
-This pipeline checks that a given `*.json` file complies with an associated `*.schema.json` file. Right now it is only being used in the `build-ci` repo.
+This pipeline calls a reusable workflow (namely, [validate-json.yml](https://github.com/ACCESS-NRI/build-ci/blob/main/.github/workflows/validate-json.yml)) that checks that a given `*.json` file complies with an associated `*.schema.json` file. Right now it is only being used in the `build-ci` repo.
 
 ## Usage
 


### PR DESCRIPTION
Makes the JSON Validate workflow usable by:
* creating a new reusable workflow that has a `workflow_call` trigger (called `validate-json.yml`)
  * Remove references to directories (specifically `containers`) and referring to `workflow_call.inputs.src`
  * Expand all the flags of commands from their short version to the long version for more understandability (for example, `-R` to `--raw-input` for the call to `jq`)
* Simplifying the actual call in `json-1-validate.yml` to simply call the newly created workflow above. 

Closes #104 !