### PR TITLE
Building Docker images uses Nirin Runner

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -31,7 +31,7 @@ jobs:
   build-and-push-image:
     name: Build ${{ inputs.container-name }}
 
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
 
     permissions:
       contents: read

--- a/.github/workflows/dep-image-1-start.yml
+++ b/.github/workflows/dep-image-1-start.yml
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         compiler: ${{ fromJson(needs.generate-matrix.outputs.compilers) }}
-    uses: access-nri/build-ci/.github/workflows/dep-image-2-build-base.yml@main
+    uses: access-nri/build-ci/.github/workflows/dep-image-2-build-base.yml@112-nirin-workflows
     with:
       compiler-name: ${{ matrix.compiler.name }}
       compiler-package: ${{ matrix.compiler.package }}

--- a/.github/workflows/dep-image-2-build-base.yml
+++ b/.github/workflows/dep-image-2-build-base.yml
@@ -47,7 +47,7 @@ jobs:
     needs: 
       - base-spack-image-check
     if: needs.base-spack-image-check.outputs.no-image-exists
-    uses: access-nri/build-ci/.github/workflows/build-docker-image.yml@main
+    uses: access-nri/build-ci/.github/workflows/build-docker-image.yml@112-nirin-workflows
     with:
       container-registry: ghcr.io
       container-name: access-nri/base-spack-${{ inputs.compiler-name }}${{ inputs.compiler-version }}-${{ inputs.spack-packages-version }}
@@ -79,7 +79,7 @@ jobs:
       fail-fast: false
       matrix:
         model: ${{ fromJson(inputs.models) }}
-    uses: access-nri/build-ci/.github/workflows/dep-image-3-build.yml@main
+    uses: access-nri/build-ci/.github/workflows/dep-image-3-build.yml@112-nirin-workflows
     with:
       compiler-name: ${{ inputs.compiler-name }}
       compiler-package: ${{ inputs.compiler-package }}

--- a/.github/workflows/dep-image-3-build.yml
+++ b/.github/workflows/dep-image-3-build.yml
@@ -33,7 +33,7 @@ jobs:
     name: Build build-${{ inputs.model }}-${{ inputs.compiler-name}}${{ inputs.compiler-version }}-${{ inputs.spack-packages-version }}
     needs:
       - setup-dependency-image
-    uses: access-nri/build-ci/.github/workflows/build-docker-image.yml@main
+    uses: access-nri/build-ci/.github/workflows/build-docker-image.yml@112-nirin-workflows
     with:
       container-registry: ghcr.io
       container-name: access-nri/build-${{ inputs.model}}-${{ inputs.compiler-name }}${{ inputs.compiler-version }}-${{ inputs.spack-packages-version }}


### PR DESCRIPTION
In this PR:
* Update to build-docker-image.yml to use `self-hosted` runner rather than `ubuntu-latest`.

Closes #112 !