### PR TITLE
Dockerfile.base-spack: explicitly install cmake 3.24.2

### DIFF
--- a/containers/Dockerfile.base-spack
+++ b/containers/Dockerfile.base-spack
@@ -148,7 +148,7 @@ FROM base-spack as dev
 RUN spack load ${COMPILER_PACKAGE}@${COMPILER_VERSION} \
  && spack compiler find
 
-RUN spack install cmake%${COMPILER_NAME}@${COMPILER_VERSION} \
+RUN spack install cmake@3.24.2%${COMPILER_NAME}@${COMPILER_VERSION} \
     gmake%${COMPILER_NAME}@${COMPILER_VERSION} \
     openmpi@4.0.2%${COMPILER_NAME}@${COMPILER_VERSION} \
     arch=${SPACK_ENV_ARCH}


### PR DESCRIPTION
* The latest cmake version in Gadi's /apps is 3.24.2