### PR TITLE
Dockerfile.base-spack: clone a spack release branch instead of a tag

### DIFF
--- a/containers/Dockerfile.base-spack
+++ b/containers/Dockerfile.base-spack
@@ -52,7 +52,7 @@ RUN dnf update -y \
 ################################################################################
 FROM base-os as base-spack
 
-ARG SPACK_REPO_VERSION=v0.20.1
+ARG SPACK_REPO_VERSION=releases/v0.20
 ARG SPACK_PACKAGES_REPO_VERSION=main
 ARG SPACK_CONFIG_REPO_VERSION=main
 ARG SPACK_ARCH=linux-rocky8-x86_64


### PR DESCRIPTION
Cloning a release branch enables important bug fixes, via minor releases, to be automatically received without having to update this Dockerfile after each minor release creates a new tag.