### PR TITLE
Dockerfile.base-spack: use versioned target directories of spack_config

### DIFF
--- a/containers/Dockerfile.base-spack
+++ b/containers/Dockerfile.base-spack
@@ -52,7 +52,8 @@ RUN dnf update -y \
 ################################################################################
 FROM base-os as base-spack
 
-ARG SPACK_REPO_VERSION=releases/v0.20
+ARG SPACK_VERSION=v0.20
+ARG SPACK_REPO_VERSION=releases/${SPACK_VERSION}
 ARG SPACK_PACKAGES_REPO_VERSION=main
 ARG SPACK_CONFIG_REPO_VERSION=main
 ARG SPACK_ARCH=linux-rocky8-x86_64
@@ -62,11 +63,10 @@ ARG COMPILER_NAME=intel
 
 ENV SPACK_ROOT=/opt/spack
 ENV GNUPGHOME=${SPACK_ROOT}/opt/spack/gpg
-ENV SPACK_REPO_VERSION=${SPACK_REPO_VERSION}
 ENV SPACK_ENV_ARCH=${SPACK_ARCH}
 ENV SPACK_PACKAGES_REPO_ROOT=/opt/spack_packages
 ENV SPACK_CONFIG_REPO_ROOT=/opt/spack_config
-ENV SPACK_CONFIG_DIR=${SPACK_CONFIG_REPO_ROOT}/config
+ENV SPACK_CONFIG_DIR=${SPACK_CONFIG_REPO_ROOT}/${SPACK_VERSION}/ci
 ENV SPACK_ENV_COMPILER_PACKAGE=${COMPILER_PACKAGE}
 ENV SPACK_ENV_COMPILER_VERSION=${COMPILER_VERSION}
 ENV SPACK_ENV_COMPILER_NAME=${COMPILER_NAME}
@@ -81,15 +81,13 @@ SHELL ["/bin/bash", "-c"]
 # Install spack
 RUN git clone -c feature.manyFiles=true https://github.com/spack/spack.git ${SPACK_ROOT} --branch ${SPACK_REPO_VERSION} --single-branch --depth=1
 
+# Install ACCESS-NRI's spack_packages repo
+RUN git clone  https://github.com/ACCESS-NRI/spack_packages.git ${SPACK_PACKAGES_REPO_ROOT} --branch ${SPACK_PACKAGES_REPO_VERSION}
+
 # Install ACCESS-NRI's spack_config repo
 RUN git clone  https://github.com/ACCESS-NRI/spack_config.git ${SPACK_CONFIG_REPO_ROOT} --branch ${SPACK_CONFIG_REPO_VERSION}
 
-RUN ln -s ${SPACK_CONFIG_DIR}/concretizer.yaml ${SPACK_ROOT}/etc/spack/ \
- && ln -s ${SPACK_CONFIG_DIR}/config.yaml ${SPACK_ROOT}/etc/spack/ \
- && ln -s ${SPACK_CONFIG_DIR}/repos.yaml ${SPACK_ROOT}/etc/spack/
-# We don't want to use, only relevant for Gadi:
-#     ${SPACK_CONFIG_DIR}/packages.yaml
-#     ${SPACK_CONFIG}/linux/compilers.yaml
+RUN ln -s -r -v ${SPACK_CONFIG_DIR}/* ${SPACK_ROOT}/etc/spack/
 
 # Enables setting Spack setup type via SHELL command
 # docker-shell:      Use for build RUN steps
@@ -112,11 +110,6 @@ SHELL ["docker-shell"]
 
 # Install compilers
 RUN spack install ${SPACK_ENV_COMPILER_PACKAGE}@${SPACK_ENV_COMPILER_VERSION} arch=${SPACK_ENV_ARCH}
-
-# Install ACCESS-NRI's spack_packages repo
-RUN git clone  https://github.com/ACCESS-NRI/spack_packages.git ${SPACK_PACKAGES_REPO_ROOT} --branch ${SPACK_PACKAGES_REPO_VERSION}
-
-RUN spack repo add ${SPACK_PACKAGES_REPO_ROOT}
 
 
 ################################################################################


### PR DESCRIPTION
* No need to do `spack repo add` because it's already in spack_config