### PR TITLE
Proper multiline secret containment

### DIFF
--- a/.github/workflows/dep-image-2-build.yml
+++ b/.github/workflows/dep-image-2-build.yml
@@ -61,8 +61,8 @@ jobs:
           build-secrets: |
             S3_ACCESS_KEY_ID=${{ secrets.S3_ACCESS_KEY_ID }}
             S3_ACCESS_KEY_SECRET=${{ secrets.S3_ACCESS_KEY_SECRET }}
-            access-nri.priv=${{ secrets.BUILDCACHE_KEY_PRIVATE }}
-            access-nri.pub=${{ secrets.BUILDCACHE_KEY_PUBLIC }}
+            "access-nri.priv=${{ secrets.BUILDCACHE_KEY_PRIVATE }}"
+            "access-nri.pub=${{ secrets.BUILDCACHE_KEY_PUBLIC }}"
 
   dependency-images:
     name: Dependency Images


### PR DESCRIPTION
In this PR:
* Containing multiline gpg file secrets in quotes, as noted in https://docs.docker.com/build/ci/github-actions/secrets/

Closes #130﻿
