### PR TITLE
Adding checking out of `models.json` during dependency image creation

### DIFF
--- a/.github/workflows/dep-image-2-build.yml
+++ b/.github/workflows/dep-image-2-build.yml
@@ -74,6 +74,8 @@ jobs:
       matrix:
         model: ${{ fromJson(inputs.models) }}
     steps:
+      - uses: actions/checkout@v4
+
       - name: Get model components for ${{ matrix.model }}
         id: get-model-components
         run: echo "model-components=$(jq -cr '.["${{ matrix.model }}"]' config/models.json)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
During the reconfiguration of `build-ci`, a regression was introduced that meant the `models.json` was being read without being checked out, leading to a dependency image that didn't actually have any dependencies in it.  