### PR TITLE
Added step in Model Build workflow to activate spack

### DIFF
--- a/.github/workflows/model-1-build.yml
+++ b/.github/workflows/model-1-build.yml
@@ -90,6 +90,9 @@ jobs:
           echo "GH_REF=${{ github.ref_name }})" >> $GITHUB_ENV
         fi
 
+    - name: Activate spack
+      run: . ./share/spack/setup-env.sh
+
     - name: Activate environment
       run: spack env activate ${{ needs.setup-model.outputs.package-name }}
 


### PR DESCRIPTION
Due to GitHub Actions not honoring Dockers `ENTRYPOINT` command, we need to activate spack using the provided `$SPACK/share/spack/setup-env.sh` script. 