### PR TITLE
Dependency Image Spack fix

### DIFF
--- a/.github/workflows/model-1-build.yml
+++ b/.github/workflows/model-1-build.yml
@@ -117,6 +117,10 @@ jobs:
     - name: Generate force-concretized lockfile
       if: failure()
       run: |
+        . $SPACK_ROOT/share/spack/setup-env.sh
+        spack load ${{ matrix.compiler.package }}@${{ matrix.compiler.version }}
+        spack compiler find
+        spack env activate ${{ env.PACKAGE_NAME }}
         spack concretize --force
         cp ${{ env.SPACK_YAML_LOCATION }}/spack.lock /lockfiles/force.spack.lock
 

--- a/.github/workflows/model-1-build.yml
+++ b/.github/workflows/model-1-build.yml
@@ -110,7 +110,7 @@ jobs:
         cp ${{ env.SPACK_YAML_LOCATION }}/spack.yaml /lockfiles/generic.spack.yaml
         cp ${{ env.SPACK_YAML_LOCATION }}/spack.lock /lockfiles/generic.spack.lock
         echo "------------------------------------------------------------------------------"
-        spack change --match-spec ${{ env.PACKAGE_NAME }} ${{ env.PACKAGE_NAME }}@git.$GH_REF%intel@2021.2.0 arch=linux-rocky8-x86_64
+        spack change --match-spec ${{ env.PACKAGE_NAME }} ${{ env.PACKAGE_NAME }}@git.$GH_REF%${{ matrix.compiler.name }}@${{ matrix.compiler.version }} arch=$SPACK_ENV_ARCH
         spack concretize --reuse
         spack find --show-concretized --long
         cp ${{ env.SPACK_YAML_LOCATION }}/spack.yaml /lockfiles/current.spack.yaml

--- a/.github/workflows/model-1-build.yml
+++ b/.github/workflows/model-1-build.yml
@@ -15,11 +15,13 @@ jobs:
           repository: access-nri/spack-packages
           ref: main
           fetch-tags: true
+
       - name: Fetch history for main
         # By default, actions/checkout only checks out `--depth=1` (the tip of the main branch).
         # Even when we fetch tags the history is fragmented and usually isn't traversable from HEAD with `git describe --tags`.
         # We fetch the entirety of the main branch history to be able to do the next step.
         run: git fetch --unshallow
+
       - name: Get latest spack-packages tags
         id: get-version
         # This command traverses `main` to find the last `git tag` and suppresses the 'long form' of tags (that have a bunch of commit metadata).
@@ -48,9 +50,11 @@ jobs:
     - uses: actions/checkout@v3
       with:
         repository: access-nri/build-ci
+
     - name: Get compilers to test
       id: get-compilers
       run: echo "compilers=$(jq -c . config/compilers.json)" >> $GITHUB_OUTPUT
+
     - name: Get model to test
       id: get-model
       # model-components are associated with an overarching model (for example, cice5 is associated with access-om2), this uses models.json to find the associated model

--- a/.github/workflows/model-1-build.yml
+++ b/.github/workflows/model-1-build.yml
@@ -74,12 +74,18 @@ jobs:
         compiler: ${{ fromJson(needs.setup-build-ci.outputs.compilers) }}
     permissions:
       packages: read
+    env:
+      PACKAGE_NAME: ${{ needs.setup-model.outputs.package-name }}
+      SPACK_YAML_LOCATION: $SPACK_ROOT/var/spack/environments/${{ needs.setup-model.outputs.package-name }}
 
     container:
       image: ghcr.io/access-nri/build-${{ needs.setup-build-ci.outputs.model }}-${{ matrix.compiler.name }}${{ matrix.compiler.version }}-${{ needs.setup-spack-packages.outputs.version }}:latest
       credentials:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
+      options: --interactive --tty
+      volumes:
+        - /lockfiles:/lockfiles
 
     steps:
     - name: Get correct ref
@@ -90,49 +96,34 @@ jobs:
           echo "GH_REF=${{ github.ref_name }}" >> $GITHUB_ENV
         fi
 
-    - name: Activate spack
-      run: . $SPACK_ROOT/share/spack/setup-env.sh
-
-    - name: Activate environment
-      run: spack env activate ${{ needs.setup-model.outputs.package-name }}
-
-    - name: Build package via spack
-      run: spack -d install --add --only package --fail-fast --no-checksum ${{ needs.setup-model.outputs.package-name }}@=$GH_REF%${{ matrix.compiler.name }}@${{ matrix.compiler.version }}
-
-    - name: Generate lockfile
+    - name: Build ${{ env.PACKAGE_NAME }} via spack
       run: |
-        cd $SPACK_ROOT/var/spack/environments/${{ needs.setup-model.outputs.package-name }}
-        cp spack.lock ${{ needs.setup-model.outputs.package-name }}.original.spack.lock
+        . $SPACK_ROOT/share/spack/setup-env.sh
+        spack load ${{ matrix.compiler.package }}@${{ matrix.compiler.version }}
+        spack compiler find
+        spack env activate ${{ env.PACKAGE_NAME }}
+        spack find --show-concretized --long
+        cp ${{ env.SPACK_YAML_LOCATION }}/spack.yaml /lockfiles/generic.spack.yaml
+        cp ${{ env.SPACK_YAML_LOCATION }}/spack.lock /lockfiles/generic.spack.lock
+        echo "------------------------------------------------------------------------------"
+        spack change --match-spec ${{ env.PACKAGE_NAME }} ${{ env.PACKAGE_NAME }}@git.$GH_REF%intel@2021.2.0 arch=linux-rocky8-x86_64
+        spack concretize --reuse
+        spack find --show-concretized --long
+        cp ${{ env.SPACK_YAML_LOCATION }}/spack.yaml /lockfiles/current.spack.yaml
+        cp ${{ env.SPACK_YAML_LOCATION }}/spack.lock /lockfiles/current.spack.lock
+        echo "------------------------------------------------------------------------------"
+        spack install
 
     - name: Generate force-concretized lockfile
       if: failure()
       run: |
-        cd $SPACK_ROOT/var/spack/environments/${{ needs.setup-model.outputs.package-name }}
-        spack -d concretize --force
-        cp spack.lock ${{ needs.setup-model.outputs.package-name }}.force.spack.lock
+        spack concretize --force
+        cp ${{ env.SPACK_YAML_LOCATION }}/spack.lock /lockfiles/force.spack.lock
 
     - name: Upload lockfiles
+      if: always()
       uses: actions/upload-artifact@v3
       with:
-        name: lockfile-output
-        path: $SPACK_ROOT/var/spack/environments/${{ needs.setup-model.outputs.package-name }}/${{ needs.setup-model.outputs.package-name }}.*.spack.lock
-
-
-    # Install and launch interactive debugging on build failure
-    - name: Install tmate on failure
-      run: |
-        dnf -y install epel-release
-        dnf -y install libevent-devel ncurses-devel msgpack-devel libssh-devel
-        git clone https://github.com/tmate-io/tmate.git
-        cd tmate
-        ./autogen.sh
-        ./configure
-        make
-        make install
-      if: ${{ failure() }}
-
-    - name: Debug with tmate on failure
-      uses: mxschmitt/action-tmate@v3
-      if: ${{ failure() }}
-      with:
-        install-dependencies: false
+        name: ${{ env.PACKAGE_NAME }}
+        path: /lockfiles/*.spack.*
+        if-no-files-found: error

--- a/containers/Dockerfile.dependency
+++ b/containers/Dockerfile.dependency
@@ -17,11 +17,11 @@ SHELL ["docker-shell"]
 COPY setup-spack-envs.sh .
 
 RUN chmod +x setup-spack-envs.sh \
- && ./setup-spack-envs.sh "${PACKAGE_NAMES}" \
- && spack gc -y
+ && ./setup-spack-envs.sh "${PACKAGE_NAMES}"
 
 # Push any uncached binaries to buildcache
 RUN spack -d buildcache create -a -m s3_buildcache $(spack find --json | jq --raw-output .[].name)
 
-ENTRYPOINT ["/bin/bash", "/opt/spack/share/spack/docker/entrypoint.bash"]
-CMD ["interactive-shell"]
+# NOTE: We do not use an ENTRYPOINT as would be expected by a spack-based image (i.e. to call
+# $SPACK_ROOT/share/spack/docker/entrypoint.bash) because GitHub Actions overrides the Dockerfile-defined
+# ENTRYPOINT to put in their own logic.


### PR DESCRIPTION
In this PR:
* `Dockerfile.dependency`: 
  * Removed garbage collection as it was deleting packages that would be reinstalled later
  * Removed `ENTRYPOINT` command and added a comment noting why it isn't there (see: https://stackoverflow.com/questions/66358482/github-actions-ignores-overrides-docker-containers-entrypoint)
* `model-1-build.yml`: 
  * Added setup of environment and compilers when running the container
  * Added volumes that store various environment files that are uploaded as artifacts
  * Removed `tmate` remote debugging because the logs should be sufficient 
  * Cleaned up some of the code and logic

Closes #137
