### PR TITLE
Dockerfile.base-spack: remove cmake version from dev target

### DIFF
--- a/containers/Dockerfile.base-spack
+++ b/containers/Dockerfile.base-spack
@@ -141,7 +141,7 @@ FROM base-spack as dev
 RUN spack load ${COMPILER_PACKAGE}@${COMPILER_VERSION} \
  && spack compiler find
 
-RUN spack install cmake@3.24.2%${COMPILER_NAME}@${COMPILER_VERSION} \
+RUN spack install cmake%${COMPILER_NAME}@${COMPILER_VERSION} \
     gmake%${COMPILER_NAME}@${COMPILER_VERSION} \
     openmpi@4.0.2%${COMPILER_NAME}@${COMPILER_VERSION} \
     arch=${SPACK_ENV_ARCH}


### PR DESCRIPTION
The CMake version will now come from the spack-config repository. See https://github.com/ACCESS-NRI/spack-config/pull/21 .