### PR TITLE
Dockerfile.base-spack: add arch arg after each compiler arg

### DIFF
--- a/containers/Dockerfile.base-spack
+++ b/containers/Dockerfile.base-spack
@@ -144,8 +144,9 @@ ARG MPI_VERSION=4.0.2
 RUN spack load ${COMPILER_PACKAGE}@${COMPILER_VERSION} \
  && spack compiler find
 
-RUN spack install cmake%${COMPILER_NAME}@${COMPILER_VERSION} \
-    gmake%${COMPILER_NAME}@${COMPILER_VERSION} \
+RUN spack install \
+    cmake%${COMPILER_NAME}@${COMPILER_VERSION} arch=${SPACK_ENV_ARCH} \
+    gmake%${COMPILER_NAME}@${COMPILER_VERSION} arch=${SPACK_ENV_ARCH} \
     ${MPI_NAME}@${MPI_VERSION}%${COMPILER_NAME}@${COMPILER_VERSION} \
     arch=${SPACK_ENV_ARCH}
 


### PR DESCRIPTION
From v0.20 to v0.21, Spack appears to have changed the permitted syntax of compiler and arch arguments during a spack install. See https://github.com/ACCESS-NRI/build-ci/issues/139