### PR TITLE
Dockerfile.base-spack: explicitly install perl in base-os

### DIFF
--- a/containers/Dockerfile.base-spack
+++ b/containers/Dockerfile.base-spack
@@ -35,6 +35,7 @@ RUN dnf update -y \
     make \
     patch \
     patchutils \
+    perl \
     pkgconf \
     pkgconf-m4 \
     pkgconf-pkg-config \


### PR DESCRIPTION
Perl is installed implicitly as a dependency in target base-os. Make it explicit now that we do not build it via Spack.
See https://github.com/ACCESS-NRI/spack-config/pull/22