### PR TITLE
Dockerfile.base-spack: check if $SPACK_CONFIG_DIR exists

### DIFF
--- a/containers/Dockerfile.base-spack
+++ b/containers/Dockerfile.base-spack
@@ -88,7 +88,9 @@ RUN git clone  https://github.com/ACCESS-NRI/spack-packages.git ${SPACK_PACKAGES
 # Install ACCESS-NRI's spack-config repo
 RUN git clone  https://github.com/ACCESS-NRI/spack-config.git ${SPACK_CONFIG_REPO_ROOT} --branch ${SPACK_CONFIG_REPO_VERSION}
 
-RUN ln -s -r -v ${SPACK_CONFIG_DIR}/* ${SPACK_ROOT}/etc/spack/
+# Exit with ENOENT 2 "No such file or directory", if the directory does not
+# exist
+RUN if [ -d "${SPACK_CONFIG_DIR}" ]; then ln -s -r -v ${SPACK_CONFIG_DIR}/* ${SPACK_ROOT}/etc/spack/; else echo "${SPACK_CONFIG_DIR} does not exist!"; exit 2; fi
 
 # Enables setting Spack setup type via SHELL command
 # docker-shell:      Use for build RUN steps


### PR DESCRIPTION
While attemping to test a new version of Spack via the Docker image, I noticed that $SPACK_ROOT/etc/spack didn't contain symlinks to spack-config config files. This change will generate an ENOENT error, if the directory for a particular Spack version does not exist.