### PR TITLE
Dockerfile.base-spack: upgrade from Rocky Linux 8.8 to 8.9

### DIFF
--- a/containers/Dockerfile.base-spack
+++ b/containers/Dockerfile.base-spack
@@ -6,7 +6,7 @@
 ################################################################################
 # NOTE: Keep an eye on:
 #       ${SPACK_ROOT}/share/spack/templates/container/rockylinux_8.dockerfile
-FROM rockylinux:8.8 as base-os
+FROM rockylinux:8.9 as base-os
 
 # csh currently required for some build scripts e.g. MOM5
 RUN dnf update -y \


### PR DESCRIPTION
* Gadi has been upgraded to Rocky Linux 8.9.