### PR TITLE
Added entry for `intel@2021.4.0` in `config/compilers.json` 

### DIFF
--- a/config/compilers.json
+++ b/config/compilers.json
@@ -3,5 +3,10 @@
     "name": "intel",
     "package": "intel-oneapi-compilers",
     "version": "2021.2.0"
+  },
+  {
+    "name": "intel",
+    "package": "intel-oneapi-compilers",
+    "version": "2021.4.0"
   }
 ]


### PR DESCRIPTION
In this PR: 
* Added entry in `compilers` table for `intel@2021.4.0` as `intel@2021.2.0` can't be downloaded at the moment

Closes #148 