### PR TITLE
compilers.json: Removed intel@2021.4.0

### DIFF
--- a/config/compilers.json
+++ b/config/compilers.json
@@ -2,11 +2,6 @@
   {
     "name": "intel",
     "package": "intel-oneapi-compilers",
-    "version": "2021.2.0"
-  },
-  {
-    "name": "intel",
-    "package": "intel-oneapi-compilers",
     "version": "2021.4.0"
   }
 ]


### PR DESCRIPTION
See https://github.com/ACCESS-NRI/build-ci/actions/runs/8291385383/job/22690995420#step:4:3320

Due to this compiler failing to be fetched from intels sources, we have removed it and replaced it with `intel@2021.4.0`. 