### PR TITLE
Dockerfile: decouple compiler package version and compiler version

### DIFF
--- a/containers/Dockerfile.base-spack
+++ b/containers/Dockerfile.base-spack
@@ -59,24 +59,26 @@ ARG SPACK_REPO_VERSION=releases/${SPACK_VERSION}
 ARG SPACK_PACKAGES_REPO_VERSION=main
 ARG SPACK_CONFIG_REPO_VERSION=main
 ARG SPACK_ARCH=linux-rocky8-x86_64
-ARG COMPILER_PACKAGE=intel-oneapi-compilers
-ARG COMPILER_VERSION=2021.2.0
+ARG COMPILER_PKG_NAME=intel-oneapi-compilers
+ARG COMPILER_PKG_VERSION=2021.2.0
 ARG COMPILER_NAME=intel
+ARG COMPILER_VERSION=2021.2.0
 
 ENV SPACK_ROOT=/opt/spack
 ENV GNUPGHOME=${SPACK_ROOT}/opt/spack/gpg
-ENV SPACK_ENV_ARCH=${SPACK_ARCH}
+ENV ENV_SPACK_ARCH=${SPACK_ARCH}
 ENV SPACK_PACKAGES_REPO_ROOT=/opt/spack-packages
 ENV SPACK_CONFIG_REPO_ROOT=/opt/spack-config
 ENV SPACK_CONFIG_DIR=${SPACK_CONFIG_REPO_ROOT}/${SPACK_VERSION}/ci
-ENV SPACK_ENV_COMPILER_PACKAGE=${COMPILER_PACKAGE}
-ENV SPACK_ENV_COMPILER_VERSION=${COMPILER_VERSION}
-ENV SPACK_ENV_COMPILER_NAME=${COMPILER_NAME}
+ENV ENV_COMPILER_PKG_NAME=${COMPILER_PKG_NAME}
+ENV ENV_COMPILER_PKG_VERSION=${COMPILER_PKG_VERSION}
+ENV ENV_COMPILER_NAME=${COMPILER_NAME}
+ENV ENV_COMPILER_VERSION=${COMPILER_VERSION}
 
 LABEL au.org.access-nri.image.spack-repo-version ${SPACK_REPO_VERSION}
 LABEL au.org.access-nri.image.spack-packages-repo-version ${SPACK_PACKAGES_REPO_VERSION}
-LABEL au.org.access-nri.image.compiler ${SPACK_ENV_COMPILER_PACKAGE}@${SPACK_ENV_COMPILER_VERSION}
-LABEL au.org.access-nri.image.arch ${SPACK_ENV_ARCH}
+LABEL au.org.access-nri.image.compiler ${ENV_COMPILER_NAME}@${ENV_COMPILER_VERSION}
+LABEL au.org.access-nri.image.arch ${ENV_SPACK_ARCH}
 
 SHELL ["/bin/bash", "-c"]
 
@@ -113,7 +115,7 @@ SHELL ["docker-shell"]
 # i.e. the first time they are needed and can’t be found.
 
 # Install compilers
-RUN spack install ${SPACK_ENV_COMPILER_PACKAGE}@${SPACK_ENV_COMPILER_VERSION} arch=${SPACK_ENV_ARCH}
+RUN spack install ${ENV_COMPILER_PKG_NAME}@${ENV_COMPILER_PKG_VERSION} arch=${ENV_SPACK_ARCH}
 
 
 ################################################################################
@@ -145,14 +147,14 @@ FROM base-spack as dev
 ARG MPI_NAME=openmpi
 ARG MPI_VERSION=4.0.2
 
-RUN spack load ${COMPILER_PACKAGE}@${COMPILER_VERSION} \
+RUN spack load ${COMPILER_PKG_NAME}@${COMPILER_PKG_VERSION} \
  && spack compiler find
 
 RUN spack install \
-    cmake%${COMPILER_NAME}@${COMPILER_VERSION} arch=${SPACK_ENV_ARCH} \
-    gmake%${COMPILER_NAME}@${COMPILER_VERSION} arch=${SPACK_ENV_ARCH} \
-    ${MPI_NAME}@${MPI_VERSION}%${COMPILER_NAME}@${COMPILER_VERSION} \
-    arch=${SPACK_ENV_ARCH}
+    cmake%${ENV_COMPILER_NAME}@${ENV_COMPILER_VERSION} arch=${ENV_SPACK_ARCH} \
+    gmake%${ENV_COMPILER_NAME}@${ENV_COMPILER_VERSION} arch=${ENV_SPACK_ARCH} \
+    ${MPI_NAME}@${MPI_VERSION}%${ENV_COMPILER_NAME}@${ENV_COMPILER_VERSION} \
+    arch=${ENV_SPACK_ARCH}
 
 ENTRYPOINT ["/bin/bash", "/opt/spack/share/spack/docker/entrypoint.bash"]
 CMD ["interactive-shell"]

--- a/containers/Dockerfile.dependency
+++ b/containers/Dockerfile.dependency
@@ -9,7 +9,7 @@ LABEL au.org.access-nri.ci.packages ${PACKAGE_NAMES}
 LABEL au.org.access-nri.ci.base-spack-image ${BASE_IMAGE}
 LABEL au.org.access-nri.ci.spack-repo-version ${SPACK_REPO_VERSION}
 LABEL au.org.access-nri.ci.spack-packages-repo-version ${SPACK_PACKAGES_REPO_VERSION}
-LABEL au.org.access-nri.ci.compiler ${SPACK_ENV_COMPILER_PACKAGE}@${SPACK_ENV_COMPILER_VERSION}
+LABEL au.org.access-nri.ci.compiler ${ENV_COMPILER_NAME}@${ENV_COMPILER_VERSION}
 
 # Use Spack shell environment for subsequent RUN steps
 SHELL ["docker-shell"]

--- a/containers/setup-spack-envs.sh
+++ b/containers/setup-spack-envs.sh
@@ -7,9 +7,9 @@ PACKAGES="${1}"
 for PACKAGE in ${PACKAGES}; do
   spack env create ${PACKAGE}
   spack env activate ${PACKAGE}
-  spack -d install -j 4 --add --fail-fast ${SPACK_ENV_COMPILER_PACKAGE}@${SPACK_ENV_COMPILER_VERSION} arch=${SPACK_ENV_ARCH}
-  spack load ${SPACK_ENV_COMPILER_PACKAGE}@${SPACK_ENV_COMPILER_VERSION} arch=${SPACK_ENV_ARCH}
+  spack -d install -j 4 --add --fail-fast ${ENV_COMPILER_PKG_NAME}@${ENV_COMPILER_PKG_VERSION} arch=${ENV_SPACK_ARCH}
+  spack load ${ENV_COMPILER_PKG_NAME}@${ENV_COMPILER_PKG_VERSION} arch=${ENV_SPACK_ARCH}
   spack compiler find --scope env:${PACKAGE}
-  spack -d install -j 4 --add --only dependencies --fail-fast ${PACKAGE}%${SPACK_ENV_COMPILER_NAME}@${SPACK_ENV_COMPILER_VERSION} arch=${SPACK_ENV_ARCH}
+  spack -d install -j 4 --add --only dependencies --fail-fast ${PACKAGE}%${ENV_COMPILER_NAME}@${ENV_COMPILER_VERSION} arch=${ENV_SPACK_ARCH}
   spack env deactivate
 done


### PR DESCRIPTION
* The newer Intel oneAPI compiler packages contain a legacy Fortran compiler and a modern LLVM Fortran compiler. The compiler package version does not correspond with the legacy Fortran compiler version.