### PR TITLE
CI/CD: Updated ENV_SPACK_ARCH Variable

### DIFF
--- a/.github/workflows/model-1-build.yml
+++ b/.github/workflows/model-1-build.yml
@@ -110,7 +110,7 @@ jobs:
         cp ${{ env.SPACK_YAML_LOCATION }}/spack.yaml /lockfiles/generic.spack.yaml
         cp ${{ env.SPACK_YAML_LOCATION }}/spack.lock /lockfiles/generic.spack.lock
         echo "------------------------------------------------------------------------------"
-        spack change --match-spec ${{ env.PACKAGE_NAME }} ${{ env.PACKAGE_NAME }}@git.$GH_REF%${{ matrix.compiler.name }}@${{ matrix.compiler.version }} arch=$SPACK_ENV_ARCH
+        spack change --match-spec ${{ env.PACKAGE_NAME }} ${{ env.PACKAGE_NAME }}@git.$GH_REF%${{ matrix.compiler.name }}@${{ matrix.compiler.version }} arch=$ENV_SPACK_ARCH
         spack concretize --reuse
         spack find --show-concretized --long
         cp ${{ env.SPACK_YAML_LOCATION }}/spack.yaml /lockfiles/current.spack.yaml


### PR DESCRIPTION
This PR came about due to this https://github.com/CABLE-LSM/CABLE/pull/271 - specifically https://github.com/CABLE-LSM/CABLE/actions/runs/8794039008/job/24132843568?pr=271#step:4:10 - we had renamed a variable in the Dockerfile (PR here: https://github.com/ACCESS-NRI/build-ci/pull/155) but didn't do it in the CI. 

In this PR:
* model-1-build.yml: Replaced `$SPACK_ENV_ARCH` with `$ENV_SPACK_ARCH`