### PR TITLE
Default compiler update from `intel@2021.2.0` to `intel@2021.4.0`

### DIFF
--- a/config/compilers.json
+++ b/config/compilers.json
@@ -2,6 +2,6 @@
   {
     "name": "intel",
     "package": "intel-oneapi-compilers",
-    "version": "2021.2.0"
+    "version": "2021.4.0"
   }
 ]


### PR DESCRIPTION
In this PR:
* Updating compiler to 2021.4.0 from 2021.2.0 to further https://github.com/CABLE-LSM/CABLE/pull/271