### PR TITLE
Dockerfile additions to workflow

### DIFF
--- a/.github/workflows/dep-image-1-start.yml
+++ b/.github/workflows/dep-image-1-start.yml
@@ -55,10 +55,10 @@ jobs:
         compiler: ${{ fromJson(needs.generate-matrix.outputs.compilers) }}
     uses: access-nri/build-ci/.github/workflows/dep-image-2-build.yml@main
     with:
-      compiler-name: ${{ matrix.compiler.name }}
-      compiler-package: ${{ matrix.compiler.package }}
-      compiler-package-version: ${{ matrix.compiler.package-version }}
-      compiler-version: ${{ matrix.compiler.version }}
+      compiler-name: ${{ matrix.compiler.COMPILER_NAME }}
+      compiler-package: ${{ matrix.compiler.COMPILER_PKG_NAME }}
+      compiler-package-version: ${{ matrix.compiler.COMPILER_PKG_VERSION }}
+      compiler-version: ${{ matrix.compiler.COMPILER_VERSION }}
       spack-packages-version: ${{ inputs.spack-packages-version }}
       spack-config-version: ${{ inputs.spack-config-version }}
       models: ${{ needs.generate-matrix.outputs.models }}

--- a/.github/workflows/dep-image-1-start.yml
+++ b/.github/workflows/dep-image-1-start.yml
@@ -7,7 +7,12 @@ on:
         required: true
         type: string
         default: "main"
-        description: "Either a git tag or branch name for the ACCESS-NRI/spack-packages repository, which defaults to the main branch"
+        description: "Either a git tag or branch name for the ACCESS-NRI/spack-packages repository"
+      spack-config-version:
+        required: true
+        type: string
+        default: "main"
+        description: "Either a git tag or branch name for the ACCESS-NRI/spack-config repository"
       model:
         required: true
         type: string
@@ -52,8 +57,10 @@ jobs:
     with:
       compiler-name: ${{ matrix.compiler.name }}
       compiler-package: ${{ matrix.compiler.package }}
+      compiler-package-version: ${{ matrix.compiler.package-version }}
       compiler-version: ${{ matrix.compiler.version }}
       spack-packages-version: ${{ inputs.spack-packages-version }}
+      spack-config-version: ${{ inputs.spack-config-version }}
       models: ${{ needs.generate-matrix.outputs.models }}
     permissions:
       packages: write

--- a/.github/workflows/dep-image-1-start.yml
+++ b/.github/workflows/dep-image-1-start.yml
@@ -56,9 +56,9 @@ jobs:
     uses: access-nri/build-ci/.github/workflows/dep-image-2-build.yml@main
     with:
       compiler-name: ${{ matrix.compiler.COMPILER_NAME }}
-      compiler-package: ${{ matrix.compiler.COMPILER_PKG_NAME }}
-      compiler-package-version: ${{ matrix.compiler.COMPILER_PKG_VERSION }}
       compiler-version: ${{ matrix.compiler.COMPILER_VERSION }}
+      compiler-pkg-name: ${{ matrix.compiler.COMPILER_PKG_NAME }}
+      compiler-pkg-version: ${{ matrix.compiler.COMPILER_PKG_VERSION }}
       spack-packages-version: ${{ inputs.spack-packages-version }}
       spack-config-version: ${{ inputs.spack-config-version }}
       models: ${{ needs.generate-matrix.outputs.models }}

--- a/.github/workflows/dep-image-2-build.yml
+++ b/.github/workflows/dep-image-2-build.yml
@@ -5,14 +5,20 @@ on:
       spack-packages-version:
         description: the tag/branch of the access-nri/spack-packages repo to use
         type: string
+      spack-config-version:
+        description: the tag/branch of the access-nri/spack-config repo to use
+        type: string
       compiler-name:
         description: the short name of the compiler
         type: string
       compiler-package:
         description: the spack-specific package name of the compiler
         type: string
+      compiler-package-version:
+        description: the spack-specific version of the compiler package
+        type: string
       compiler-version:
-        description: the spack-specific package version of the compiler
+        description: the spack-specific version of the compiler
         type: string
       models:
         description: a json-string array of all models to be built in a matrix strategy
@@ -55,9 +61,11 @@ jobs:
           target: "ci"
           build-args: |
             SPACK_PACKAGES_REPO_VERSION=${{ inputs.spack-packages-version }}
+            SPACK_CONFIG_REPO_VERSION=${{ inputs.spack-config-version }}
             COMPILER_NAME=${{ inputs.compiler-name }}
-            COMPILER_PACKAGE=${{ inputs.compiler-package }}
             COMPILER_VERSION=${{ inputs.compiler-version }}
+            COMPILER_PKG_NAME=${{ inputs.compiler-package }}
+            COMPILER_PKG_VERSION=${{ inputs.compiler-package-version }}
           build-secrets: |
             S3_ACCESS_KEY_ID=${{ secrets.S3_ACCESS_KEY_ID }}
             S3_ACCESS_KEY_SECRET=${{ secrets.S3_ACCESS_KEY_SECRET }}

--- a/.github/workflows/dep-image-2-build.yml
+++ b/.github/workflows/dep-image-2-build.yml
@@ -11,15 +11,16 @@ on:
       compiler-name:
         description: the short name of the compiler
         type: string
-      compiler-package:
-        description: the spack-specific package name of the compiler
-        type: string
-      compiler-package-version:
-        description: the spack-specific version of the compiler package
-        type: string
       compiler-version:
         description: the spack-specific version of the compiler
         type: string
+      compiler-pkg-name:
+        description: the spack-specific package name of the compiler
+        type: string
+      compiler-pkg-version:
+        description: the spack-specific version of the compiler package
+        type: string
+
       models:
         description: a json-string array of all models to be built in a matrix strategy
         type: string
@@ -64,8 +65,8 @@ jobs:
             SPACK_CONFIG_REPO_VERSION=${{ inputs.spack-config-version }}
             COMPILER_NAME=${{ inputs.compiler-name }}
             COMPILER_VERSION=${{ inputs.compiler-version }}
-            COMPILER_PKG_NAME=${{ inputs.compiler-package }}
-            COMPILER_PKG_VERSION=${{ inputs.compiler-package-version }}
+            COMPILER_PKG_NAME=${{ inputs.compiler-pkg-name }}
+            COMPILER_PKG_VERSION=${{ inputs.compiler-pkg-version }}
           build-secrets: |
             S3_ACCESS_KEY_ID=${{ secrets.S3_ACCESS_KEY_ID }}
             S3_ACCESS_KEY_SECRET=${{ secrets.S3_ACCESS_KEY_SECRET }}

--- a/.github/workflows/model-1-build.yml
+++ b/.github/workflows/model-1-build.yml
@@ -102,7 +102,7 @@ jobs:
 
     - name: Build ${{ env.PACKAGE_NAME }} via spack
       run: |
-        . $SPACK_ROOT/share/spack/setup-env.sh
+        . $SPACK_ROOT/../spack-config/spack-enable.bash
         spack load ${{ matrix.compiler.package }}@${{ matrix.compiler.version }}
         spack compiler find
         spack env activate ${{ env.PACKAGE_NAME }}

--- a/config/compilers.json
+++ b/config/compilers.json
@@ -1,7 +1,8 @@
 [
   {
     "name": "intel",
-    "package": "intel-oneapi-compilers",
-    "version": "2021.4.0"
+    "package": "intel-oneapi-compilers-classic",
+    "package-version": "2021.6.0",
+    "version": "2021.10.0"
   }
 ]

--- a/config/compilers.json
+++ b/config/compilers.json
@@ -1,8 +1,8 @@
 [
   {
-    "name": "intel",
-    "package": "intel-oneapi-compilers-classic",
-    "package-version": "2021.6.0",
-    "version": "2021.10.0"
+    "COMPILER_NAME": "intel",
+    "COMPILER_VERSION": "2021.10.0",
+    "COMPILER_PKG_NAME": "intel-oneapi-compilers-classic",
+    "COMPILER_PKG_VERSION": "2021.6.0"
   }
 ]

--- a/config/compilers.json
+++ b/config/compilers.json
@@ -1,8 +1,8 @@
 [
   {
     "COMPILER_NAME": "intel",
-    "COMPILER_VERSION": "2021.10.0",
-    "COMPILER_PKG_NAME": "intel-oneapi-compilers-classic",
-    "COMPILER_PKG_VERSION": "2021.6.0"
+    "COMPILER_VERSION": "2021.2.0",
+    "COMPILER_PKG_NAME": "intel-oneapi-compilers",
+    "COMPILER_PKG_VERSION": "2021.2.0"
   }
 ]

--- a/config/compilers.schema.json
+++ b/config/compilers.schema.json
@@ -6,20 +6,20 @@
     "items": {
         "type": "object",
         "properties": {
-            "name": {
+            "COMPILER_NAME": {
                 "type": "string"
             },
-            "package": {
+            "COMPILER_VERSION": {
                 "type": "string"
             },
-            "package-version": {
+            "COMPILER_PKG_NAME": {
                 "type": "string"
             },
-            "version": {
+            "COMPILER_PKG_VERSION": {
                 "type": "string"
             }
         },
-        "required": [ "name", "package", "package-version", "version" ],
+        "required": [ "COMPILER_NAME", "COMPILER_VERSION", "COMPILER_PKG_NAME", "COMPILER_PKG_VERSION" ],
         "additionalProperties": false
     }
 }

--- a/config/compilers.schema.json
+++ b/config/compilers.schema.json
@@ -12,11 +12,14 @@
             "package": {
                 "type": "string"
             },
+            "package-version": {
+                "type": "string"
+            },
             "version": {
                 "type": "string"
             }
         },
-        "required": [ "name", "package", "version" ],
+        "required": [ "name", "package", "package-version", "version" ],
         "additionalProperties": false
     }
 }


### PR DESCRIPTION
Bringing the `build-ci` workflow in line with the improvements to the Docker Image. 

In this PR:
* Workflow now uses the `spack-config` repository
* Workflow now uses a new field in `compilers.json` - the `package-version` of the compiler, so it doesn't default to `2021.2.0` in the repository. 

Closes #161 