### PR TITLE
Update `spack buildcache` command for `spack >=0.21`

### DIFF
--- a/containers/Dockerfile.dependency
+++ b/containers/Dockerfile.dependency
@@ -20,7 +20,7 @@ RUN chmod +x setup-spack-envs.sh \
  && ./setup-spack-envs.sh "${PACKAGE_NAMES}"
 
 # Push any uncached binaries to buildcache
-RUN spack -d buildcache create -a -m s3_buildcache $(spack find --json | jq --raw-output .[].name)
+RUN spack -d buildcache create --allow-root s3_buildcache $(spack find --json | jq --raw-output .[].name)
 
 # NOTE: We do not use an ENTRYPOINT as would be expected by a spack-based image (i.e. to call
 # $SPACK_ROOT/share/spack/docker/entrypoint.bash) because GitHub Actions overrides the Dockerfile-defined

--- a/containers/Dockerfile.dependency
+++ b/containers/Dockerfile.dependency
@@ -20,7 +20,7 @@ RUN chmod +x setup-spack-envs.sh \
  && ./setup-spack-envs.sh "${PACKAGE_NAMES}"
 
 # Push any uncached binaries to buildcache
-RUN spack -d buildcache create --allow-root s3_buildcache $(spack find --json | jq --raw-output .[].name)
+RUN spack -d buildcache push --allow-root s3_buildcache $(spack find --json | jq --raw-output .[].name)
 
 # NOTE: We do not use an ENTRYPOINT as would be expected by a spack-based image (i.e. to call
 # $SPACK_ROOT/share/spack/docker/entrypoint.bash) because GitHub Actions overrides the Dockerfile-defined


### PR DESCRIPTION
The `0.20` version of the image contained a (deprecated) `-m` flag in the `spack buildcache create` command (see https://spack.readthedocs.io/en/v0.20.3/command_index.html#spack-buildcache-push).

In the later version (https://spack.readthedocs.io/en/latest/command_index.html#spack-buildcache-push, updated in https://github.com/ACCESS-NRI/build-ci/pull/166), the `-m` flag is removed, instead taking mirror as a positional argument. This PR uses the mirror as a positional arg. 

In this PR:
* Removed the -m flag as `mirror` is now positional