### PR TITLE
Dependency Images not building due to `spack buildcache push` clashing packages

### DIFF
--- a/containers/Dockerfile.dependency
+++ b/containers/Dockerfile.dependency
@@ -20,7 +20,8 @@ RUN chmod +x setup-spack-envs.sh \
  && ./setup-spack-envs.sh "${PACKAGE_NAMES}"
 
 # Push any uncached binaries to buildcache
-RUN spack -d buildcache push --allow-root s3_buildcache $(spack find --json | jq --raw-output .[].name)
+RUN spack -d buildcache push --allow-root s3_buildcache
+
 
 # NOTE: We do not use an ENTRYPOINT as would be expected by a spack-based image (i.e. to call
 # $SPACK_ROOT/share/spack/docker/entrypoint.bash) because GitHub Actions overrides the Dockerfile-defined


### PR DESCRIPTION
See https://github.com/ACCESS-NRI/build-ci/actions/runs/9605847929/job/26494707679#step:4:9413

The [new](https://github.com/ACCESS-NRI/build-ci/pull/167) `spack buildcache push` command is rejecting pushes of packages that have the same name. In this PR, we remove the `jq` that gives all the packages that we want to push - by default it will push all the packages in the environment (with hashes appended). 

In this PR:
* Update the `spack buildcache push` command to push packages of a specific hash