### PR TITLE
Add back `jq` to `spack buildcache push`

### DIFF
--- a/containers/setup-spack-envs.sh
+++ b/containers/setup-spack-envs.sh
@@ -12,6 +12,6 @@ for PACKAGE in ${PACKAGES}; do
   spack compiler find --scope env:${PACKAGE}
   spack -d install -j 4 --add --only dependencies --fail-fast ${PACKAGE}%${ENV_COMPILER_NAME}@${ENV_COMPILER_VERSION} arch=${ENV_SPACK_ARCH}
   # Push any uncached binaries to buildcache
-  spack -d buildcache push --allow-root s3_buildcache
+  spack -d buildcache push s3_buildcache "$(spack find --json | jq --raw-output '.[] | (.name + "/" + .hash)')"
   spack env deactivate
 done


### PR DESCRIPTION
See failed run: https://github.com/ACCESS-NRI/build-ci/actions/runs/9608705872/job/26501970133#step:4:8470

Using `spack buildcache push` without a list of `specs` assumes that you want to push all of them. However, if not all of them are installed (as is the case in our dependency image, which `spack install --only dependencies ...`) it fails. So leaving the `jq` in was needed. 
To solve the original issue in https://github.com/ACCESS-NRI/build-ci/pull/168, we now get both the name of the package, and the hash, so we can push up different versions of the same package. 
We also remove the `--allow-root` flag as it is assumed in `0.21`, and removed in `0.22`.

In this PR:
* setup-spack-envs.sh: Removed --allow-root (assumed in 0.21), added back hash-delineated jq