### PR TITLE
Intermittent Push Failures for `access-nri/docker-build-push` action

### DIFF
--- a/.github/workflows/dep-image-2-build.yml
+++ b/.github/workflows/dep-image-2-build.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Build base-spack-${{ inputs.compiler-name }}${{ inputs.compiler-version }}-${{ inputs.spack-packages-version }}
         if: steps.no-image-exists.outputs.check
-        uses: access-nri/actions/.github/actions/docker-build-push@main
+        uses: access-nri/actions/.github/actions/docker-build-push@170-intermittent-push-fail
         with:
           container-registry: ghcr.io
           image-name: access-nri/base-spack-${{ inputs.compiler-name }}${{ inputs.compiler-version }}-${{ inputs.spack-packages-version }}
@@ -90,7 +90,7 @@ jobs:
         run: echo "model-components=$(jq -cr '.["${{ matrix.model }}"]|join(" ")' config/models.json)" >> $GITHUB_OUTPUT
 
       - name: Build build-${{ matrix.model }}-${{ inputs.compiler-name}}${{ inputs.compiler-version }}-${{ inputs.spack-packages-version }}
-        uses: access-nri/actions/.github/actions/docker-build-push@main
+        uses: access-nri/actions/.github/actions/docker-build-push@170-intermittent-push-fail
         with:
           container-registry: ghcr.io
           image-name: access-nri/build-${{ matrix.model}}-${{ inputs.compiler-name }}${{ inputs.compiler-version }}-${{ inputs.spack-packages-version }}


### PR DESCRIPTION
In this PR:
* `dep-image-2-build.yml`: Moved `access-nri/docker-build-push` action to `170-intermittent-push-fail` PR branch temporarily during testing

Closes #170 