### PR TITLE
Update `env.SPACK_YAML_LOCATION` to reference new `spack-config` Update

### DIFF
--- a/.github/workflows/model-1-build.yml
+++ b/.github/workflows/model-1-build.yml
@@ -80,7 +80,7 @@ jobs:
       packages: read
     env:
       PACKAGE_NAME: ${{ needs.setup-model.outputs.package-name }}
-      SPACK_YAML_LOCATION: $SPACK_ROOT/var/spack/environments/${{ needs.setup-model.outputs.package-name }}
+      SPACK_YAML_LOCATION: $SPACK_ROOT/../environments/${{ needs.setup-model.outputs.package-name }}
 
     container:
       image: ghcr.io/access-nri/build-${{ needs.setup-build-ci.outputs.model }}-${{ matrix.compiler.COMPILER_NAME }}${{ matrix.compiler.COMPILER_VERSION }}-${{ needs.setup-spack-packages.outputs.version }}:latest


### PR DESCRIPTION
In this PR:
- Update `env.SPACK_YAML_LOCATION` to `$SPACK_ROOT/../environments` due to ACCESS-NRI/spack-config@8a0425e595218e43b340587e8c04fd34f113bddb

Closes #178
