### PR TITLE
Dockerfile.base-spack: build gmake before cmake

### DIFF
--- a/containers/Dockerfile.base-spack
+++ b/containers/Dockerfile.base-spack
@@ -204,9 +204,13 @@ RUN spack load ${COMPILER_PKG_NAME}@${COMPILER_PKG_VERSION} \
  && spack compiler find
 
 RUN spack install \
-    cmake%${COMPILER_NAME}@${COMPILER_VERSION} target=${SPACK_TARGET} \
-    gmake%${COMPILER_NAME}@${COMPILER_VERSION} target=${SPACK_TARGET} \
-    ${MPI_NAME}@${MPI_VERSION}%${COMPILER_NAME}@${COMPILER_VERSION} \
+    gmake %${COMPILER_NAME}@${COMPILER_VERSION} target=${SPACK_TARGET}
+
+RUN spack install \
+    cmake %${COMPILER_NAME}@${COMPILER_VERSION} target=${SPACK_TARGET}
+
+RUN spack install \
+    ${MPI_NAME}@${MPI_VERSION} %${COMPILER_NAME}@${COMPILER_VERSION} \
     target=${SPACK_TARGET}
 
 ENTRYPOINT ["/bin/bash", "/opt/spack/share/spack/docker/entrypoint.bash"]


### PR DESCRIPTION
* This ensures that cmake depends on the gmake built with the compiler we selected.