### PR TITLE
Updated compiler to 2021.10.0

### DIFF
--- a/config/compilers.json
+++ b/config/compilers.json
@@ -1,8 +1,8 @@
 [
   {
     "COMPILER_NAME": "intel",
-    "COMPILER_VERSION": "2021.2.0",
+    "COMPILER_VERSION": "2021.10.0",
     "COMPILER_PKG_NAME": "intel-oneapi-compilers",
-    "COMPILER_PKG_VERSION": "2021.2.0"
+    "COMPILER_PKG_VERSION": "2023.2.4"
   }
 ]


### PR DESCRIPTION
References #205

## Background

There has been an issue with `build-ci` in which components are failing to be built.

## The PR

In this PR:

* We update the compiler package version to `2023.2.4`, and the compiler version to `2021.10.0`
