### PR TITLE
Output SHAs even when refs aren't updated

### DIFF
--- a/.github/actions/git-checkout-updated-ref/README.md
+++ b/.github/actions/git-checkout-updated-ref/README.md
@@ -14,6 +14,7 @@ Action that updates an existing repository, and checks out the updated ref.
 | Name | Type | Description | Example |
 | ---- | ---- | ----------- | ------- |
 | `sha` | `string` (sha) | The SHA of the checked out ref | `"5a1cdc4e4617fcd6ba1cccf1cd0432b5631983be"` |
+| `updated` | `string` (boolean) | Whether there was actually an update to the ref | `"true"` or `"false"` |
 
 ## Examples
 

--- a/.github/actions/git-checkout-updated-ref/action.yml
+++ b/.github/actions/git-checkout-updated-ref/action.yml
@@ -11,12 +11,21 @@ inputs:
 outputs:
   sha:
     description: 'The SHA of the checked out ref'
-    value: ${{ steps.checkout.outputs.sha }}
+    value: ${{ steps.update.outputs.sha }}
+  updated:
+    description: 'Whether the repository was updated'
+    value: ${{ steps.post-update.outputs.updated }}
 runs:
   using: composite
   steps:
+    - name: Get initial SHA
+      id: initial
+      working-directory: ${{ inputs.repository-path }}
+      shell: bash
+      run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
     - shell: bash
-      id: checkout
+      id: update
       working-directory: ${{ inputs.repository-path }}
       run: |
         git fetch --all --tags
@@ -26,7 +35,19 @@ runs:
           git checkout -B ${{ inputs.ref }} origin/${{ inputs.ref }}
         else  # checkout the tag/commit
           echo "Checking out the tag/commit ${{ inputs.ref }}"
-          git checkout ${{ inputs.ref}}
+          git checkout ${{ inputs.ref }}
         fi
 
         echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+    - name: Check if updated
+      id: post-update
+      shell: bash
+      run: |
+        if [ "${{ steps.initial.outputs.sha }}" != "${{ steps.update.outputs.sha }}" ]; then
+          echo "Repository was updated from ${{ steps.initial.outputs.sha }} to ${{ steps.update.outputs.sha }}"
+          echo "updated=true" >> $GITHUB_OUTPUT
+        else
+          echo "Repository was not updated, stayed at ${{ steps.initial.outputs.sha }}"
+          echo "updated=false" >> $GITHUB_OUTPUT
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,6 @@ jobs:
           echo "spack-env-dir=$(realpath $SPACK_ROOT/../environments)" >> $GITHUB_OUTPUT
 
       - name: Update spack-package version
-        if: steps.env.outputs.SPACK_PACKAGES_REPO_VERSION != inputs.spack-packages-ref
         id: spack-packages-update
         uses: access-nri/build-ci/.github/actions/git-checkout-updated-ref@build-ci-2.0
         with:
@@ -137,7 +136,6 @@ jobs:
           ref: ${{ inputs.spack-packages-ref }}
 
       - name: Update spack-config version
-        if: steps.env.outputs.SPACK_CONFIG_REPO_VERSION != inputs.spack-config-ref
         id: spack-config-update
         uses: access-nri/build-ci/.github/actions/git-checkout-updated-ref@build-ci-2.0
         with:
@@ -145,7 +143,6 @@ jobs:
           ref: ${{ inputs.spack-config-ref }}
 
       - name: Update spack version
-        if: steps.env.outputs.SPACK_REPO_VERSION != inputs.spack-ref
         id: spack-update
         uses: access-nri/build-ci/.github/actions/git-checkout-updated-ref@build-ci-2.0
         with:
@@ -153,7 +150,7 @@ jobs:
           ref: ${{ inputs.spack-ref }}
 
       - name: Relink spack-config to spack
-        if: steps.spack-config-update.conclusion == 'success' || steps.spack-update.conclusion == 'success'
+        if: steps.spack-config-update.outputs.updated == 'true' || steps.spack-update.outputs.updated == 'true'
         run: ln --symbolic --relative --verbose --force ${{ steps.env.outputs.SPACK_CONFIG_DIR }}/* ${{ steps.env.outputs.SPACK_ROOT }}/etc/spack/
 
       - name: Spack - Initial Enable + Compiler Load

--- a/util/generate_buildcache_keys.sh
+++ b/util/generate_buildcache_keys.sh
@@ -1,9 +1,0 @@
-# Convenience script for generating new Spack buildcache keypair
-
-# Create and export new keypair
-spack gpg create ACCESS-NRI access.nri@anu.edu.au \
---export ./access-nri.pub \
---export-secret ./access-nri.priv
-
-# Publish public key to buildcache
-spack publish -m s3_buildcache


### PR DESCRIPTION
## Background

See https://github.com/ACCESS-NRI/MOM5/actions/runs/15695675683/job/44220448187#step:2:143

When we use the default values for `*-ref` inputs, we skip the relevant repo update steps. However, this is how we get the SHAs that are outputted, leading to no SHAs outputted for repos that use defaults. 

In this PR, we no longer skip the update action steps, and output the SHA (updated or not) in that action. We also add a new output `updated` that allows a later relinking step (between `spack` and `spack-config`) only go ahead if those repos were updated. 

## The PR

In this PR:

- **Update git-checkout-updated-ref to note whether the ref was actually updated**
- **Always attempt to update refs, and only relink config to spack if actually updated**
- **Delete util folder as we don't need buildcache keys**
- **TEST: Update action ref for testing**

## Testing

Tested on `MOM5` here: https://github.com/ACCESS-NRI/MOM5/actions/runs/15698218709/job/44227413029 using all defaults (shows how quickly things can go out of date!)