### PR TITLE
Dockerfile.base-spack: install the which package on Rocky Linux

### DIFF
--- a/containers/Dockerfile.base-spack
+++ b/containers/Dockerfile.base-spack
@@ -50,6 +50,7 @@ RUN dnf update -y \
     python3-setuptools \
     svn \
     unzip \
+    which \
     xz \
     zstd \
  && rm -rf /var/cache/dnf \


### PR DESCRIPTION
* Needed to build ROMS Spack Package Recipe
* SUSE 15.5 has the package dependency chain: git -> git-core -> less -> which
* On Rocky Linux 8.10, nothing depends on the which package, hence we need to install it explicitly.