### PR TITLE
Build-ci 1.0 - Checkout `v1` branch for config rather than default branch

### DIFF
--- a/.github/workflows/model-1-build.yml
+++ b/.github/workflows/model-1-build.yml
@@ -64,6 +64,8 @@ jobs:
     - uses: actions/checkout@v3
       with:
         repository: access-nri/build-ci
+        # Since this old version of build-ci uses a configuration format that is only on this branch, we need to use `v1` rather than the default branch.
+        ref: v1
 
     - name: Get compilers to test
       id: get-compilers


### PR DESCRIPTION
For repositories still using the earlier version of `build-ci`, they checkout configuration information from the default branch. Since later versions of `build-ci` don't use this configuration information, the workflow fails. 

## The PR

* Pin the ref that is checked out for the earlier version of `build-ci`  to the `v1` branch
