### PR TITLE
Update Upstream Image Packages and Dependencies

### DIFF
--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -57,7 +57,11 @@ RUN dnf update -y \
  && rm -rf /var/cache/dnf \
  && dnf clean all \
  && curl -L https://github.com/mikefarah/yq/releases/download/v4.45.1/yq_linux_amd64 -o /usr/bin/yq \
- && chmod +x /usr/bin/yq
+ && chmod +x /usr/bin/yq \
+ && curl -L https://github.com/tmate-io/tmate/releases/download/2.4.0/tmate-2.4.0-static-linux-amd64.tar.xz -o static-tmate.tar.xz \
+ && tar -xvf static-tmate.tar.xz --strip-components=1 \
+ && mv tmate /usr/local/bin/tmate \
+ && rm -rf static-tmate.tar.xz
 
 ################################################################################
 FROM opensuse/leap:15.5 AS base-os-suse
@@ -103,7 +107,11 @@ RUN zypper ref \
     vim \
  &&  zypper clean \
  && curl -L https://github.com/mikefarah/yq/releases/download/v4.45.1/yq_linux_amd64 -o /usr/bin/yq \
- && chmod +x /usr/bin/yq
+ && chmod +x /usr/bin/yq \
+ && curl -L https://github.com/tmate-io/tmate/releases/download/2.4.0/tmate-2.4.0-static-linux-amd64.tar.xz -o static-tmate.tar.xz \
+ && tar -xvf static-tmate.tar.xz --strip-components=1 \
+ && mv tmate /usr/local/bin/tmate \
+ && rm -rf static-tmate.tar.xz
 
 ################################################################################
 FROM base-os-$OS AS base-spack
@@ -214,12 +222,6 @@ FROM base-spack AS runner
 LABEL org.opencontainers.image.source=https://github.com/ACCESS-NRI/build-ci
 
 # Install tmate on the runner for remote access during workflows via mxschmitt/action-tmate
-RUN <<EOF
-curl -L https://github.com/tmate-io/tmate/releases/download/2.4.0/tmate-2.4.0-static-linux-amd64.tar.xz -o static-tmate.tar.xz
-tar -xvf static-tmate.tar.xz --strip-components=1
-mv tmate /usr/local/bin/tmate
-rm -rf static-tmate.tar.xz
-EOF
 
 # Set up ACCESS Spack buildcache
 RUN spack mirror add --autopush --unsigned runner_set_buildcache /opt/runner_set_buildcache

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -58,6 +58,7 @@ RUN dnf update -y \
  && dnf clean all \
  && curl -L https://github.com/mikefarah/yq/releases/download/v4.45.1/yq_linux_amd64 -o /usr/bin/yq \
  && chmod +x /usr/bin/yq \
+# Install tmate in the image for remote access during workflows via mxschmitt/action-tmate
  && curl -L https://github.com/tmate-io/tmate/releases/download/2.4.0/tmate-2.4.0-static-linux-amd64.tar.xz -o static-tmate.tar.xz \
  && tar -xvf static-tmate.tar.xz --strip-components=1 \
  && mv tmate /usr/local/bin/tmate \
@@ -108,6 +109,7 @@ RUN zypper ref \
  &&  zypper clean \
  && curl -L https://github.com/mikefarah/yq/releases/download/v4.45.1/yq_linux_amd64 -o /usr/bin/yq \
  && chmod +x /usr/bin/yq \
+ # Install tmate in the image for remote access during workflows via mxschmitt/action-tmate
  && curl -L https://github.com/tmate-io/tmate/releases/download/2.4.0/tmate-2.4.0-static-linux-amd64.tar.xz -o static-tmate.tar.xz \
  && tar -xvf static-tmate.tar.xz --strip-components=1 \
  && mv tmate /usr/local/bin/tmate \
@@ -220,8 +222,6 @@ EOF
 FROM base-spack AS runner
 
 LABEL org.opencontainers.image.source=https://github.com/ACCESS-NRI/build-ci
-
-# Install tmate on the runner for remote access during workflows via mxschmitt/action-tmate
 
 # Set up ACCESS Spack buildcache
 RUN spack mirror add --autopush --unsigned runner_set_buildcache /opt/runner_set_buildcache

--- a/containers/upstream/dev/packages.spack.yaml
+++ b/containers/upstream/dev/packages.spack.yaml
@@ -6,6 +6,8 @@ spack:
       - cmake@3.24.4
       - openmpi@4.1.5
       - openmpi@5.0.3
+      - netcdf-c@4.9.2
+      - netcdf-fortran@4.5.2
 
     # Compilers to install the packages
     - compilers:

--- a/containers/upstream/prod/packages.spack.yaml
+++ b/containers/upstream/prod/packages.spack.yaml
@@ -6,6 +6,8 @@ spack:
       - cmake@3.24.4
       - openmpi@4.1.5
       - openmpi@5.0.3
+      - netcdf-c@4.9.2
+      - netcdf-fortran@4.5.2
 
     # Compilers to install the packages
     - compilers:


### PR DESCRIPTION
## Background

CABLE-LSM/CABLE is using a prototype GitHub-hosted CI 2.0 without a buildcache at the moment. This means that builds are actually slower than the original, everything-except-the-dependent way. 

To get it as close as we can, we should include relevant versions of `netcdf-c` and `netcdf-fortran` in the upstream image. 

Furthermore, since we can't share data between service containers in GitHub-hosted mode, we have elected to just run the upstream container as the runner container. This means that the upstream image requires tmate to be installed. 

## The PR

- **Add tmate to both runner and upstream images**
- **Add netcdf-c@4.9.2 and netcdf-fortran@4.5.2 to upstream packages**
