### PR TITLE
Allow specification of container image version, allow aggregation of matrix instance outputs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -212,7 +212,7 @@ spack:
 
 #### Using outputs of a Matrix Job
 
-If you need to aggregate data across multiple instances of a matrix job, you will need to use the `job-output-artifact-pattern` output rather than individual job outputs through `needs`, due to GitHubs instances of jobs overwriting the sole matrix job output. This pattern, when used as an argument to `actions/download-artifact`, will have all the inputs, outputs and conclusion of each instance of the matrix job, in JSON. In a dependent later job, you will need to merge all these artifacts together and parse them. For example:
+If you need to aggregate data across multiple instances of a matrix job, you will need to use the `job-output-artifact-pattern` output rather than individual job outputs through `needs`, due to GitHubs insistence of jobs overwriting the sole matrix job output. This pattern, when used as an argument to `actions/download-artifact`, will have all the inputs, outputs and conclusion of each instance of the matrix job, in JSON. In a dependent later job, you will need to merge all these artifacts together and parse them. For example:
 
 ```yaml
 jobs:

--- a/.github/workflows/ci-github-hosted.yml
+++ b/.github/workflows/ci-github-hosted.yml
@@ -306,10 +306,13 @@ jobs:
       - name: Job Outputs - Create
         id: output-create
         # The outputs of the job also contain the inputs to the job, so that they can be used in future jobs.
+        # We need to serialize the spec concretization graph and data pairs to a single line, so that it can be used in JSON.
         run: |
-          # We need to serialize the spec concretization graph to a single line, so that it can be used in JSON
-          serialized_spec_concretization_graph=$(sed -z 's/\n/\\n/g' <<< "${{ steps.install.outputs.spec }}")
-          serialized_spack_manifest_data_pairs=$(sed -z 's/\n/\\n/g' <<< "${{ inputs.spack-manifest-data-pairs }}")
+          echo "${{ steps.install.outputs.spec }}" > ./concretization_graph.txt
+          serialized_spec_concretization_graph=$(sed -z 's/\n/\\n/g' ./concretization_graph.txt)
+
+          echo ${{ inputs.spack-manifest-data-pairs }} > ./spack_manifest_data_pairs.txt
+          serialized_spack_manifest_data_pairs=$(sed -z 's/\n/\\n/g' ./spack_manifest_data_pairs.txt)
 
           jq --null-input \
              --arg spec "$serialized_spec_concretization_graph" \

--- a/.github/workflows/ci-github-hosted.yml
+++ b/.github/workflows/ci-github-hosted.yml
@@ -77,6 +77,14 @@ on:
           Enable the actor of the workflow to SSH into the container where the spack packages have been installed.
           This is useful for gathering post-install information before the container is destroyed.
           This will also make the workflow wait until the actor SSHs into the container, or it times out, before continuing.
+      container-image-version:
+        required: false
+        type: string
+        default: :rocky
+        description: |
+          The version of the container image to use for the runner.
+          Can be either a tag (specified by ':TAG') or a SHA (specified by '@sha256:SHA').
+          For example: ':8.9' or 'rocky@sha256:1234...'.
     secrets:
       spack-install-command-pat:
         required: false
@@ -103,10 +111,27 @@ on:
         value: ${{ jobs.spack-install-and-test.outputs.sha }}
         description: |
           The SHA of the caller model component repository checked out.
+      container-id:
+        value: ${{ jobs.spack-install-and-test.outputs.container-id }}
+        description: |
+          The ID of the container where the spack packages have been installed.
+      ## These outputs contain information on data uploaded as artifacts
+      spack-files-artifact-pattern:
+        value: ${{ jobs.spack-install-and-test.outputs.spack-files-artifact-pattern }}
+        description: |
+          Wildcard pattern to match all spack file artifacts across a matrix job.
       spack-files-artifact-url:
         value: ${{ jobs.spack-install-and-test.outputs.spack-files-artifact-url }}
         description: |
-          The URL of the spack manifest and lock files artifact.
+          The URL of the spack file artifact, which contains the spack files created.
+      job-output-artifact-pattern:
+        value: ${{ jobs.spack-install-and-test.outputs.job-output-artifact-pattern }}
+        description: |
+          Wildcard pattern to match all job output artifacts across a matrix job.
+      job-output-artifact-url:
+        value: ${{ jobs.spack-install-and-test.outputs.job-output-artifact-url }}
+        description: |
+          The URL of the job output artifact, which contains the job outputs in JSON format.
       # test-artifact-url:
       #   value: ${{}}
       #   description: |
@@ -116,14 +141,18 @@ jobs:
     name: Install and Test
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/access-nri/build-ci-upstream:rocky
+      image: ghcr.io/access-nri/build-ci-upstream${{ inputs.container-image-version }}
     outputs:
       spec-concretization-graph: ${{ steps.install.outputs.spec }}
       spack-sha: ${{ steps.spack-update.outputs.sha }}
       spack-config-sha: ${{ steps.spack-config-update.outputs.sha }}
       spack-packages-sha: ${{ steps.spack-packages-update.outputs.sha }}
       sha: ${{ steps.checkout.outputs.commit }}
-      spack-files-artifact-url: ${{ steps.upload.outputs.artifact-url }}
+      spack-files-artifact-pattern: ${{ steps.env.outputs.spack-files-artifact-pattern }}
+      spack-files-artifact-url: ${{ steps.manifest-upload.outputs.artifact-url }}
+      job-output-artifact-pattern: ${{ steps.env.outputs.job-output-artifact-pattern }}
+      job-output-artifact-url: ${{ steps.output-upload.outputs.artifact-url }}
+      container-id: ${{ steps.env.outputs.container-id }}
       # test-artifact-url: ${{ steps.test.outputs.artifact-url }}
     steps:
       - name: Export environment variables into GitHub Actions format
@@ -139,6 +168,15 @@ jobs:
 
           # The upload step later requires a non-relative path, hence the realpath
           echo "spack-env-dir=$(realpath $SPACK_ROOT/../environments)" >> $GITHUB_OUTPUT
+
+          # We can only get the job.container.id after the container is started, so we set it as the file name here
+          echo "job-output-artifact-name=job-output-${{ job.container.id }}" >> $GITHUB_OUTPUT
+          echo 'job-output-artifact-pattern=job-output-*' >> $GITHUB_OUTPUT
+
+          echo 'spack-files-artifact-name=spack-files-${{ job.container.id }}' >> $GITHUB_OUTPUT
+          echo 'spack-files-artifact-pattern=spack-files-*' >> $GITHUB_OUTPUT
+
+          echo 'container-id=${{ job.container.id }}' >> $GITHUB_OUTPUT
 
       - name: Update spack-package version
         id: spack-packages-update
@@ -234,11 +272,11 @@ jobs:
           spack --debug install --fail-fast
 
       - name: Manifest - Upload
-        id: upload
+        id: manifest-upload
         # Upload spack manifest and lock files
         uses: actions/upload-artifact@v4
         with:
-          name: spack-files-${{ job.container.id }}
+          name: ${{ steps.env.outputs.spack-files-artifact-name }}
           path: ${{ steps.env.outputs.spack-env-dir }}/default/spack.*
           if-no-files-found: error
 
@@ -266,3 +304,43 @@ jobs:
       #   run: |
       #     python -m pytest -v -m "${{ inputs.pytest-test-markers }}" --junitxml=pytest.xml
       #     echo "pytest=$(cat pytest.xml)" >> $GITHUB_OUTPUT
+
+      - name: Job Outputs - Create
+        id: output-create
+        if: always()
+        # The outputs of the job also contain the inputs to the job, so that they can be used in future jobs.
+        run: |
+          jq --null-input '{
+            "spack_manifest_path": "${{ inputs.spack-manifest-path }}",
+            "spack_manifest_data_path": "${{ inputs.spack-manifest-data-path }}",
+            "spack_compiler_manifest_path": "${{ inputs.spack-compiler-manifest-path }}",
+            "ref": "${{ inputs.ref }}",
+            "spack_config_ref": "${{ inputs.spack-config-ref }}",
+            "spack_packages_ref": "${{ inputs.spack-packages-ref }}",
+            "spack_ref": "${{ inputs.spack-ref }}",
+            "pytest_test_markers": "${{ inputs.pytest-test-markers }}",
+            "allow_ssh_into_spack_install": "${{ inputs.allow-ssh-into-spack-install }}",
+            "container_image_version": "${{ inputs.container-image-version }}",
+
+            "spack_install_result": "${{ steps.install.conclusion }}",
+
+            "spec_concretization_graph": "${{ steps.install.outputs.spec }}",
+            "spack_sha": "${{ steps.spack-update.outputs.sha }}",
+            "spack_config_sha": "${{ steps.spack-config-update.outputs.sha }}",
+            "spack_packages_sha": "${{ steps.spack-packages-update.outputs.sha }}",
+            "sha": "${{ steps.checkout.outputs.commit }}",
+            "container_id": "${{ steps.env.outputs.container-id }}",
+            "spack_files_artifact_pattern": "${{ steps.env.outputs.spack-files-artifact-pattern }}",
+            "spack_files_artifact_url": "${{ steps.manifest-upload.outputs.artifact-url }}",
+            "job_output_artifact_pattern": "${{ steps.env.outputs.job-output-artifact-pattern }}",
+            "job_output_artifact_url": "${{ steps.env.outputs.job-output-artifact-url }}"
+          }' > ./${{ steps.env.outputs.job-output-artifact-name }}
+
+      - name: Job Outputs - Upload
+        id: output-upload
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.env.outputs.job-output-artifact-name }}
+          path: ./${{ steps.env.outputs.job-output-artifact-name }}
+          if-no-files-found: error

--- a/.github/workflows/ci-github-hosted.yml
+++ b/.github/workflows/ci-github-hosted.yml
@@ -308,11 +308,8 @@ jobs:
         # The outputs of the job also contain the inputs to the job, so that they can be used in future jobs.
         # We need to serialize the spec concretization graph and data pairs to a single line, so that it can be used in JSON.
         run: |
-          echo "${{ steps.install.outputs.spec }}" > ./concretization_graph.txt
-          serialized_spec_concretization_graph=$(sed -z 's/\n/\\n/g' ./concretization_graph.txt)
-
-          echo ${{ inputs.spack-manifest-data-pairs }} > ./spack_manifest_data_pairs.txt
-          serialized_spack_manifest_data_pairs=$(sed -z 's/\n/\\n/g' ./spack_manifest_data_pairs.txt)
+          serialized_spec_concretization_graph=$(echo "${{ steps.install.outputs.spec }}" | sed -z 's/\n/\\n/g')
+          serialized_spack_manifest_data_pairs=$(echo ${{ inputs.spack-manifest-data-pairs }} | sed -z 's/\n/\\n/g')
 
           jq --null-input \
              --arg spec "$serialized_spec_concretization_graph" \

--- a/.github/workflows/ci-github-hosted.yml
+++ b/.github/workflows/ci-github-hosted.yml
@@ -320,6 +320,7 @@ jobs:
           '{
             "spack_manifest_path": "${{ inputs.spack-manifest-path }}",
             "spack_manifest_data_path": "${{ inputs.spack-manifest-data-path }}",
+            "spack_manifest_data_pairs": $pairs,
             "spack_compiler_manifest_path": "${{ inputs.spack-compiler-manifest-path }}",
             "ref": "${{ inputs.ref }}",
             "spack_config_ref": "${{ inputs.spack-config-ref }}",
@@ -331,7 +332,7 @@ jobs:
 
             "spack_install_result": "${{ steps.install.conclusion }}",
 
-            "spec_concretization_graph": "$spec",
+            "spec_concretization_graph": $spec,
             "spack_sha": "${{ steps.spack-update.outputs.sha }}",
             "spack_config_sha": "${{ steps.spack-config-update.outputs.sha }}",
             "spack_packages_sha": "${{ steps.spack-packages-update.outputs.sha }}",
@@ -339,8 +340,7 @@ jobs:
             "container_id": "${{ steps.env.outputs.container-id }}",
             "spack_files_artifact_pattern": "${{ steps.env.outputs.spack-files-artifact-pattern }}",
             "spack_files_artifact_url": "${{ steps.manifest-upload.outputs.artifact-url }}",
-            "job_output_artifact_pattern": "${{ steps.env.outputs.job-output-artifact-pattern }}",
-            "job_output_artifact_url": "${{ steps.env.outputs.job-output-artifact-url }}"
+            "job_output_artifact_pattern": "${{ steps.env.outputs.job-output-artifact-pattern }}"
           }' > ./${{ steps.env.outputs.job-output-artifact-name }}
 
       - name: Job Outputs - Upload

--- a/.github/workflows/ci-github-hosted.yml
+++ b/.github/workflows/ci-github-hosted.yml
@@ -309,8 +309,12 @@ jobs:
         run: |
           # We need to serialize the spec concretization graph to a single line, so that it can be used in JSON
           serialized_spec_concretization_graph=$(sed -z 's/\n/\\n/g' <<< "${{ steps.install.outputs.spec }}")
+          serialized_spack_manifest_data_pairs=$(sed -z 's/\n/\\n/g' <<< "${{ inputs.spack-manifest-data-pairs }}")
 
-          jq --null-input --arg spec "$serialized_spec_concretization_graph" '{
+          jq --null-input \
+             --arg spec "$serialized_spec_concretization_graph" \
+             --arg pairs "$serialized_spack_manifest_data_pairs" \
+          '{
             "spack_manifest_path": "${{ inputs.spack-manifest-path }}",
             "spack_manifest_data_path": "${{ inputs.spack-manifest-data-path }}",
             "spack_compiler_manifest_path": "${{ inputs.spack-compiler-manifest-path }}",

--- a/.github/workflows/ci-github-hosted.yml
+++ b/.github/workflows/ci-github-hosted.yml
@@ -254,6 +254,7 @@ jobs:
 
       - name: Manifest - Install
         id: install
+        continue-on-error: true
         env:
           # This is needed to ensure that the spack install command can access private repositories - we replace all HTTPS git URLs with the PAT
           # We set the git config via environment variables, so that the PATs are not persisted in the container
@@ -281,11 +282,7 @@ jobs:
           if-no-files-found: error
 
       - name: Tmate - Create session
-        # Only create the session if the spack installation was attempted, and we want a tmate session
-        if: >-
-          always() &&
-          (steps.install.conclusion == 'failure' || steps.install.conclusion == 'success') &&
-          inputs.allow-ssh-into-spack-install
+        if: inputs.allow-ssh-into-spack-install
         id: tmate
         uses: mxschmitt/action-tmate@e5c7151931ca95bad1c6f4190c730ecf8c7dde48  # v3.19
         with:
@@ -301,13 +298,13 @@ jobs:
       # TODO: Add pytest infrastructure
       # - name: Run pytests
       #   id: test
+      #   if: steps.install.outcome == 'success'
       #   run: |
       #     python -m pytest -v -m "${{ inputs.pytest-test-markers }}" --junitxml=pytest.xml
       #     echo "pytest=$(cat pytest.xml)" >> $GITHUB_OUTPUT
 
       - name: Job Outputs - Create
         id: output-create
-        if: always()
         # The outputs of the job also contain the inputs to the job, so that they can be used in future jobs.
         run: |
           # We need to serialize the spec concretization graph to a single line, so that it can be used in JSON
@@ -341,7 +338,6 @@ jobs:
 
       - name: Job Outputs - Upload
         id: output-upload
-        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.env.outputs.job-output-artifact-name }}

--- a/.github/workflows/ci-github-hosted.yml
+++ b/.github/workflows/ci-github-hosted.yml
@@ -310,7 +310,10 @@ jobs:
         if: always()
         # The outputs of the job also contain the inputs to the job, so that they can be used in future jobs.
         run: |
-          jq --null-input '{
+          # We need to serialize the spec concretization graph to a single line, so that it can be used in JSON
+          serialized_spec_concretization_graph=$(sed -z 's/\n/\\n/g' <<< "${{ steps.install.outputs.spec }}")
+
+          jq --null-input --arg spec "$serialized_spec_concretization_graph" '{
             "spack_manifest_path": "${{ inputs.spack-manifest-path }}",
             "spack_manifest_data_path": "${{ inputs.spack-manifest-data-path }}",
             "spack_compiler_manifest_path": "${{ inputs.spack-compiler-manifest-path }}",
@@ -324,7 +327,7 @@ jobs:
 
             "spack_install_result": "${{ steps.install.conclusion }}",
 
-            "spec_concretization_graph": "${{ steps.install.outputs.spec }}",
+            "spec_concretization_graph": "$spec",
             "spack_sha": "${{ steps.spack-update.outputs.sha }}",
             "spack_config_sha": "${{ steps.spack-config-update.outputs.sha }}",
             "spack_packages_sha": "${{ steps.spack-packages-update.outputs.sha }}",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,14 @@ on:
           Enable the actor of the workflow to SSH into the container where the spack packages have been installed.
           This is useful for gathering post-install information before the container is destroyed.
           This will also make the workflow wait until the actor SSHs into the container, or it times out, before continuing.
+      container-image-version:
+        required: false
+        type: string
+        default: :rocky
+        description: |
+          The version of the container image to use for the runner.
+          Can be either a tag (specified by ':TAG') or a SHA (specified by '@sha256:SHA').
+          For example: ':8.9' or 'rocky@sha256:1234...'.
     secrets:
       spack-install-command-pat:
         required: false
@@ -103,10 +111,27 @@ on:
         value: ${{ jobs.spack-install-and-test.outputs.sha }}
         description: |
           The SHA of the caller model component repository checked out.
+      container-id:
+        value: ${{ jobs.spack-install-and-test.outputs.container-id }}
+        description: |
+          The ID of the container where the spack packages have been installed.
+      ## These outputs contain information on data uploaded as artifacts
+      spack-files-artifact-pattern:
+        value: ${{ jobs.spack-install-and-test.outputs.spack-files-artifact-pattern }}
+        description: |
+          Wildcard pattern to match all spack file artifacts across a matrix job.
       spack-files-artifact-url:
         value: ${{ jobs.spack-install-and-test.outputs.spack-files-artifact-url }}
         description: |
-          The URL of the spack manifest and lock files artifact.
+          The URL of the spack file artifact, which contains the spack files created.
+      job-output-artifact-pattern:
+        value: ${{ jobs.spack-install-and-test.outputs.job-output-artifact-pattern }}
+        description: |
+          Wildcard pattern to match all job output artifacts across a matrix job.
+      job-output-artifact-url:
+        value: ${{ jobs.spack-install-and-test.outputs.job-output-artifact-url }}
+        description: |
+          The URL of the job output artifact, which contains the job outputs in JSON format.
       # test-artifact-url:
       #   value: ${{}}
       #   description: |
@@ -117,7 +142,7 @@ jobs:
     runs-on:
       group: build-ci
     container:
-      image: ghcr.io/access-nri/build-ci-runner:rocky
+      image: ghcr.io/access-nri/build-ci-runner${{ inputs.container-image-version }}
       volumes:
         - /opt/upstream:/opt/upstream:ro
         - /opt/runner_set_buildcache:/opt/runner_set_buildcache:rw
@@ -127,7 +152,11 @@ jobs:
       spack-config-sha: ${{ steps.spack-config-update.outputs.sha }}
       spack-packages-sha: ${{ steps.spack-packages-update.outputs.sha }}
       sha: ${{ steps.checkout.outputs.commit }}
-      spack-files-artifact-url: ${{ steps.upload.outputs.artifact-url }}
+      spack-files-artifact-pattern: ${{ steps.env.outputs.spack-files-artifact-pattern }}
+      spack-files-artifact-url: ${{ steps.manifest-upload.outputs.artifact-url }}
+      job-output-artifact-pattern: ${{ steps.env.outputs.job-output-artifact-pattern }}
+      job-output-artifact-url: ${{ steps.output-upload.outputs.artifact-url }}
+      container-id: ${{ steps.env.outputs.container-id }}
       # test-artifact-url: ${{ steps.test.outputs.artifact-url }}
     steps:
       - name: Export environment variables into GitHub Actions format
@@ -143,6 +172,15 @@ jobs:
 
           # The upload step later requires a non-relative path, hence the realpath
           echo "spack-env-dir=$(realpath $SPACK_ROOT/../environments)" >> $GITHUB_OUTPUT
+
+          # We can only get the job.container.id after the container is started, so we set it as the file name here
+          echo 'job-output-artifact-name=job-output-${{ job.container.id }}' >> $GITHUB_OUTPUT
+          echo 'job-output-artifact-pattern=job-output-*' >> $GITHUB_OUTPUT
+
+          echo 'spack-files-artifact-name=spack-files-${{ job.container.id }}' >> $GITHUB_OUTPUT
+          echo 'spack-files-artifact-pattern=spack-files-*' >> $GITHUB_OUTPUT
+
+          echo 'container-id=${{ job.container.id }}' >> $GITHUB_OUTPUT
 
       - name: Update spack-package version
         id: spack-packages-update
@@ -238,11 +276,11 @@ jobs:
           spack --debug install --fail-fast
 
       - name: Manifest - Upload
-        id: upload
+        id: manifest-upload
         # Upload spack manifest and lock files
         uses: actions/upload-artifact@v4
         with:
-          name: spack-files-${{ job.container.id }}
+          name: ${{ steps.env.outputs.spack-files-artifact-name }}
           path: ${{ steps.env.outputs.spack-env-dir }}/default/spack.*
           if-no-files-found: error
 
@@ -270,3 +308,43 @@ jobs:
       #   run: |
       #     python -m pytest -v -m "${{ inputs.pytest-test-markers }}" --junitxml=pytest.xml
       #     echo "pytest=$(cat pytest.xml)" >> $GITHUB_OUTPUT
+
+      - name: Job Outputs - Create
+        id: output-create
+        if: always()
+        # The outputs of the job also contain the inputs to the job, so that they can be used in future jobs.
+        run: |
+          jq --null-input '{
+            "spack_manifest_path": "${{ inputs.spack-manifest-path }}",
+            "spack_manifest_data_path": "${{ inputs.spack-manifest-data-path }}",
+            "spack_compiler_manifest_path": "${{ inputs.spack-compiler-manifest-path }}",
+            "ref": "${{ inputs.ref }}",
+            "spack_config_ref": "${{ inputs.spack-config-ref }}",
+            "spack_packages_ref": "${{ inputs.spack-packages-ref }}",
+            "spack_ref": "${{ inputs.spack-ref }}",
+            "pytest_test_markers": "${{ inputs.pytest-test-markers }}",
+            "allow_ssh_into_spack_install": "${{ inputs.allow-ssh-into-spack-install }}",
+            "container_image_version": "${{ inputs.container-image-version }}",
+
+            "spack_install_result": "${{ steps.install.conclusion }}",
+
+            "spec_concretization_graph": "${{ steps.install.outputs.spec }}",
+            "spack_sha": "${{ steps.spack-update.outputs.sha }}",
+            "spack_config_sha": "${{ steps.spack-config-update.outputs.sha }}",
+            "spack_packages_sha": "${{ steps.spack-packages-update.outputs.sha }}",
+            "sha": "${{ steps.checkout.outputs.commit }}",
+            "container_id": "${{ steps.env.outputs.container-id }}",
+            "spack_files_artifact_pattern": "${{ steps.env.outputs.spack-files-artifact-pattern }}",
+            "spack_files_artifact_url": "${{ steps.manifest-upload.outputs.artifact-url }}",
+            "job_output_artifact_pattern": "${{ steps.env.outputs.job-output-artifact-pattern }}",
+            "job_output_artifact_url": "${{ steps.env.outputs.job-output-artifact-url }}"
+          }' > ./${{ steps.env.outputs.job-output-artifact-name }}
+
+      - name: Job Outputs - Upload
+        id: output-upload
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.env.outputs.job-output-artifact-name }}
+          path: ./${{ steps.env.outputs.job-output-artifact-name }}
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,10 +310,13 @@ jobs:
       - name: Job Outputs - Create
         id: output-create
         # The outputs of the job also contain the inputs to the job, so that they can be used in future jobs.
+        # We need to serialize the spec concretization graph and data pairs to a single line, so that it can be used in JSON.
         run: |
-          # We need to serialize the spec concretization graph to a single line, so that it can be used in JSON
-          serialized_spec_concretization_graph=$(sed -z 's/\n/\\n/g' <<< "${{ steps.install.outputs.spec }}")
-          serialized_spack_manifest_data_pairs=$(sed -z 's/\n/\\n/g' <<< "${{ inputs.spack-manifest-data-pairs }}")
+          echo "${{ steps.install.outputs.spec }}" > ./concretization_graph.txt
+          serialized_spec_concretization_graph=$(sed -z 's/\n/\\n/g' ./concretization_graph.txt)
+
+          echo ${{ inputs.spack-manifest-data-pairs }} > ./spack_manifest_data_pairs.txt
+          serialized_spack_manifest_data_pairs=$(sed -z 's/\n/\\n/g' ./spack_manifest_data_pairs.txt)
 
           jq --null-input \
              --arg spec "$serialized_spec_concretization_graph" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,7 @@ jobs:
 
       - name: Manifest - Install
         id: install
+        continue-on-error: true
         env:
           # This is needed to ensure that the spack install command can access private repositories - we replace all HTTPS git URLs with the PAT
           # We set the git config via environment variables, so that the PATs are not persisted in the container
@@ -285,11 +286,7 @@ jobs:
           if-no-files-found: error
 
       - name: Tmate - Create session
-        # Only create the session if the spack installation was attempted, and we want a tmate session
-        if: >-
-          always() &&
-          (steps.install.conclusion == 'failure' || steps.install.conclusion == 'success') &&
-          inputs.allow-ssh-into-spack-install
+        if: inputs.allow-ssh-into-spack-install
         id: tmate
         uses: mxschmitt/action-tmate@e5c7151931ca95bad1c6f4190c730ecf8c7dde48  # v3.19
         with:
@@ -305,13 +302,13 @@ jobs:
       # TODO: Add pytest infrastructure
       # - name: Run pytests
       #   id: test
+      #   if: steps.install.outcome == 'success'
       #   run: |
       #     python -m pytest -v -m "${{ inputs.pytest-test-markers }}" --junitxml=pytest.xml
       #     echo "pytest=$(cat pytest.xml)" >> $GITHUB_OUTPUT
 
       - name: Job Outputs - Create
         id: output-create
-        if: always()
         # The outputs of the job also contain the inputs to the job, so that they can be used in future jobs.
         run: |
           # We need to serialize the spec concretization graph to a single line, so that it can be used in JSON
@@ -345,7 +342,6 @@ jobs:
 
       - name: Job Outputs - Upload
         id: output-upload
-        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.env.outputs.job-output-artifact-name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,7 +314,10 @@ jobs:
         if: always()
         # The outputs of the job also contain the inputs to the job, so that they can be used in future jobs.
         run: |
-          jq --null-input '{
+          # We need to serialize the spec concretization graph to a single line, so that it can be used in JSON
+          serialized_spec_concretization_graph=$(sed -z 's/\n/\\n/g' <<< "${{ steps.install.outputs.spec }}")
+
+          jq --null-input --arg spec "$serialized_spec_concretization_graph" '{
             "spack_manifest_path": "${{ inputs.spack-manifest-path }}",
             "spack_manifest_data_path": "${{ inputs.spack-manifest-data-path }}",
             "spack_compiler_manifest_path": "${{ inputs.spack-compiler-manifest-path }}",
@@ -328,7 +331,7 @@ jobs:
 
             "spack_install_result": "${{ steps.install.conclusion }}",
 
-            "spec_concretization_graph": "${{ steps.install.outputs.spec }}",
+            "spec_concretization_graph": "$spec",
             "spack_sha": "${{ steps.spack-update.outputs.sha }}",
             "spack_config_sha": "${{ steps.spack-config-update.outputs.sha }}",
             "spack_packages_sha": "${{ steps.spack-packages-update.outputs.sha }}",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,7 +324,7 @@ jobs:
           '{
             "spack_manifest_path": "${{ inputs.spack-manifest-path }}",
             "spack_manifest_data_path": "${{ inputs.spack-manifest-data-path }}",
-            "spack_manifest_data_pairs": "$pairs",
+            "spack_manifest_data_pairs": $pairs,
             "spack_compiler_manifest_path": "${{ inputs.spack-compiler-manifest-path }}",
             "ref": "${{ inputs.ref }}",
             "spack_config_ref": "${{ inputs.spack-config-ref }}",
@@ -336,7 +336,7 @@ jobs:
 
             "spack_install_result": "${{ steps.install.conclusion }}",
 
-            "spec_concretization_graph": "$spec",
+            "spec_concretization_graph": $spec,
             "spack_sha": "${{ steps.spack-update.outputs.sha }}",
             "spack_config_sha": "${{ steps.spack-config-update.outputs.sha }}",
             "spack_packages_sha": "${{ steps.spack-packages-update.outputs.sha }}",
@@ -344,8 +344,7 @@ jobs:
             "container_id": "${{ steps.env.outputs.container-id }}",
             "spack_files_artifact_pattern": "${{ steps.env.outputs.spack-files-artifact-pattern }}",
             "spack_files_artifact_url": "${{ steps.manifest-upload.outputs.artifact-url }}",
-            "job_output_artifact_pattern": "${{ steps.env.outputs.job-output-artifact-pattern }}",
-            "job_output_artifact_url": "${{ steps.env.outputs.job-output-artifact-url }}"
+            "job_output_artifact_pattern": "${{ steps.env.outputs.job-output-artifact-pattern }}"
           }' > ./${{ steps.env.outputs.job-output-artifact-name }}
 
       - name: Job Outputs - Upload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,10 +313,15 @@ jobs:
         run: |
           # We need to serialize the spec concretization graph to a single line, so that it can be used in JSON
           serialized_spec_concretization_graph=$(sed -z 's/\n/\\n/g' <<< "${{ steps.install.outputs.spec }}")
+          serialized_spack_manifest_data_pairs=$(sed -z 's/\n/\\n/g' <<< "${{ inputs.spack-manifest-data-pairs }}")
 
-          jq --null-input --arg spec "$serialized_spec_concretization_graph" '{
+          jq --null-input \
+             --arg spec "$serialized_spec_concretization_graph" \
+             --arg pairs "$serialized_spack_manifest_data_pairs" \
+          '{
             "spack_manifest_path": "${{ inputs.spack-manifest-path }}",
             "spack_manifest_data_path": "${{ inputs.spack-manifest-data-path }}",
+            "spack_manifest_data_pairs": "$pairs",
             "spack_compiler_manifest_path": "${{ inputs.spack-compiler-manifest-path }}",
             "ref": "${{ inputs.ref }}",
             "spack_config_ref": "${{ inputs.spack-config-ref }}",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,11 +312,8 @@ jobs:
         # The outputs of the job also contain the inputs to the job, so that they can be used in future jobs.
         # We need to serialize the spec concretization graph and data pairs to a single line, so that it can be used in JSON.
         run: |
-          echo "${{ steps.install.outputs.spec }}" > ./concretization_graph.txt
-          serialized_spec_concretization_graph=$(sed -z 's/\n/\\n/g' ./concretization_graph.txt)
-
-          echo ${{ inputs.spack-manifest-data-pairs }} > ./spack_manifest_data_pairs.txt
-          serialized_spack_manifest_data_pairs=$(sed -z 's/\n/\\n/g' ./spack_manifest_data_pairs.txt)
+          serialized_spec_concretization_graph=$(echo "${{ steps.install.outputs.spec }}" | sed -z 's/\n/\\n/g')
+          serialized_spack_manifest_data_pairs=$(echo ${{ inputs.spack-manifest-data-pairs }} | sed -z 's/\n/\\n/g')
 
           jq --null-input \
              --arg spec "$serialized_spec_concretization_graph" \


### PR DESCRIPTION
## Background

It was noted while testing out the GitHub-hosted variant of the CI that it is important that the user can pin a particular version of the conatiner image, since the GitHub variant can't yet make use of the buildcache, so must use the packages installed on the image for quick installs. If a user pins a particular package hash in the manifest, via `/HASH`, this hash could change between image versions. 

Furthermore, it was noted that it is difficult to aggregate data relating to multiple instances of a matrix invocation of the CI. A similar solution to this problem was found in `build-cd`, which we reuse here - uploading an artifact per instance of the job with a common prefix, downloading all artifacts, and then processing them.

## The PR

- **Added new optional input container-image-version for image pinning**
- **Added new outputs container-id, spack-files-artifact-pattern, job-output-artifact-patttern, job-output-artifact-url for matrix job info aggregation**
- **Updated README.md to account for new inputs and outputs**

## Testing

Tested via the `spack-packages` link up to `build-ci` in PR https://github.com/ACCESS-NRI/spack-packages/pull/276, see this successful run: https://github.com/ACCESS-NRI/spack-packages/actions/runs/16487735423
