### PR TITLE
Replace intel@2025.0.4 with intel@2025.2.0, add gcc#13.2.0

### DIFF
--- a/containers/upstream/dev/compilers.spack.yaml
+++ b/containers/upstream/dev/compilers.spack.yaml
@@ -4,8 +4,9 @@ spack:
   # We can't install compilers in a matrix, because we attempt to load each of the compilers in the speclist
   # when running containers/spack-config/ci-spack-enable.bash
   specs:
+  - gcc@13.2.0 target=x86_64
   - intel-oneapi-compilers@2023.2.4 target=x86_64
-  - intel-oneapi-compilers@2025.0.4 target=x86_64
+  - intel-oneapi-compilers@2025.2.0 target=x86_64
   view: false
   concretizer:
     unify: false

--- a/containers/upstream/dev/packages.spack.yaml
+++ b/containers/upstream/dev/packages.spack.yaml
@@ -12,7 +12,7 @@ spack:
     # Compilers to install the packages
     - compilers:
       - intel@2021.10.0
-      - oneapi@2025.0.4
+      - oneapi@2025.2.0
 
     # Targets for the packages
     - targets:
@@ -25,7 +25,7 @@ spack:
     - [$targets]
   # Further specs can be installed in the usual way below, eg:
   # - gmake%intel@2021.10.0 target=x86_64
-  - python@3.11.7 %gcc@8.5.0 target=x86_64
+  - python@3.11.7 %gcc@13.2.0 target=x86_64
   view: false  # No view required as these upstream packages are not loaded by users
   concretizer:
     unify: false  # No need to unify because there are combinations of the same package

--- a/containers/upstream/prod/compilers.spack.yaml
+++ b/containers/upstream/prod/compilers.spack.yaml
@@ -4,8 +4,9 @@ spack:
   # We can't install compilers in a matrix, because we attempt to load each of the compilers in the speclist
   # when running containers/spack-config/ci-spack-enable.bash
   specs:
+  - gcc@13.2.0 target=x86_64
   - intel-oneapi-compilers@2023.2.4 target=x86_64
-  - intel-oneapi-compilers@2025.0.4 target=x86_64
+  - intel-oneapi-compilers@2025.2.0 target=x86_64
   view: false
   concretizer:
     unify: false

--- a/containers/upstream/prod/packages.spack.yaml
+++ b/containers/upstream/prod/packages.spack.yaml
@@ -12,7 +12,7 @@ spack:
     # Compilers to install the packages
     - compilers:
       - intel@2021.10.0
-      - oneapi@2025.0.4
+      - oneapi@2025.2.0
 
     # Targets for the packages
     - targets:
@@ -25,7 +25,7 @@ spack:
     - [$targets]
   # Further specs can be installed in the usual way below, eg:
   # - gmake%intel@2021.10.0 target=x86_64
-  - python@3.11.7 %gcc@8.5.0 target=x86_64
+  - python@3.11.7 %gcc@13.2.0 target=x86_64
   view: false  # No view required as these upstream packages are not loaded by users
   concretizer:
     unify: false  # No need to unify because there are combinations of the same package


### PR DESCRIPTION
## Background

The current oneapi compiler doesn't actually work well, so it's been updated. `gcc@8.5.0` is very old and shouldn't be what we test against. 

> [!NOTE]
> A new version of the image needs to be pushed before this is merged, and updated in the upstream. 