### PR TITLE
Build CI Templates

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,6 +1,6 @@
 # Entrypoint Workflows
 
-## `ci.yml` - Build and Test Workflow Entrypoint
+## `ci.yml`, `ci-github-hosted.yml` - Build and Test Workflow Entrypoint
 
 ### Overview
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A central repository for reusable CI compilation testing workflows and container
 
 ## Repositories Serviced By `build-ci`
 
-These are repositories that use the `component` tag, which can be given by either this [search url](https://github.com/search?q=org%3AACCESS-NRI%20topic%3Acomponent&type=repositories) or through `gh` with `gh search repos --owner access-nri --include-forks -- topic:component`.
+These are repositories that use the `component` tag, which can be given by either this [search url](https://github.com/search?q=org%3AACCESS-NRI%20topic%3Abuild-ci-enabled&type=repositories) or through `gh` with `gh search repos --owner access-nri --include-forks -- topic:build-ci-enabled`.
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A central repository for reusable CI compilation testing workflows and container
 
 ## Repositories Serviced By `build-ci`
 
-These are repositories that use the `component` tag, which can be given by either this [search url](https://github.com/search?q=org%3AACCESS-NRI%20topic%3Abuild-ci-enabled&type=repositories) or through `gh` with `gh search repos --owner access-nri --include-forks -- topic:build-ci-enabled`.
+These are repositories that use the `build-ci-enabled` tag, which can be given by either this [search url](https://github.com/search?q=org%3AACCESS-NRI%20topic%3Abuild-ci-enabled&type=repositories) or through `gh` with `gh search repos --owner access-nri --include-forks -- topic:build-ci-enabled`.
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,15 @@ This repository also contains the resources required to build images that are us
 
 Generally, the [`ci.yml`](./.github/workflows/ci.yml) workflow can be used by any model component repository in the ACCESS-NRI organisation, it just requires using the reusable workflow from this repository.
 
+Alternatively, for organisations outside of ACCESS-NRI, the `ci-github-hosted.yml` can be used. But...
+
+> [!IMPORTANT]
+> Note that the `ci-github-hosted.yml` is slower than the self-hosted variant due to GitHub not caching large images used to initialize compilers and packages, and the lack of a persistent buildcache.
+
+Basic templates for model component repositories CI are available under [`model-component-ci-templates`](./model-component-ci-templates/) - more complex use cases are possible and encouraged!
+
 > [!NOTE]
-> Before a model component repository workflow is able to run on the `build-ci` runners, the repository must be included in the allowlist for the `build-ci` runner group. Ask an ACCESS-NRI GitHub Administrator to add the model component repository.
+> Before a model component repository workflow using `ci.yml` is able to run on the `build-ci` runners, the repository must be included in the allowlist for the `build-ci` runner group. Ask an ACCESS-NRI GitHub Administrator to add the model component repository.
 
 The list of inputs are in the above workflow file and explained in the workflow-specific [`README.md`](./.github/workflows/README.md), but at it's simplest it only requires a path to a jinja-templatable spack manifest relative to the model component repository root (more on that in the [Writing Spack Manifests section](#writing-spack-manifests)). For example:
 

--- a/model-component-ci-templates/README.md
+++ b/model-component-ci-templates/README.md
@@ -15,11 +15,18 @@ Despite not being in these examples, Post-CI jobs can be created that make use o
 
 ### Basic CI
 
-The simplest use case - a single manifest with no customisation, single compiler already in the upstream, and the default branch for `spack-config` and `spack-packages`. We get the definitions from the `.github/build-ci/data/standard.json` Jinja data file.
+The simplest use case - a single manifest with no customisation, single compiler already in the upstream, and the default branch for `spack-config` and `spack-packages`. We get the definitions from the `.github/build-ci/data/standard.json` Jinja data file. You are free to change the compiler in the data file, or use other compilers directly in the manifest as your tests require, but in general it's good to keep to the compiler defined in `standard.json`.
 
 Further constraints can be added in the `spack.packages.PACKAGE.require` section, or on the spec itself.
 
+#### Basic CI Instructions
+
 For this case, you will use the `basic-ci.yml` and everything under `build-ci`.
+
+1. Copy `workflows/basic-ci.yml` and put it under the repository's `.github/workflows/basic-ci.yml`.
+2. Copy `build-ci/data/standard.json` and put it under `.github/build-ci/data/standard.json`, then replace `YOUR_PACKAGE_HERE` in that file with the repositories spack package under test.
+3. Copy `build-ci/manifests` and put it under `.github/build-ci/manifests`
+4. Open a PR with those changes, and the CI will run!
 
 ### Matrix CI
 
@@ -27,7 +34,14 @@ A common but simple use case - multiple manifests under `.github/build-ci/manife
 
 There is no template for these manifests, as they will be down to the MCR maintainers discretion.
 
+#### Matrix CI Instructions
+
 For this case, you will use the `matrix-ci.yml` and everything under `build-ci`.
+
+1. Copy `workflows/matrix-ci.yml` and put it under the repository's `.github/workflows/matrix-ci.yml`.
+2. Copy `build-ci/data/standard.json` and put it under `.github/build-ci/data/standard.json`, then replace `YOUR_PACKAGE_HERE` in that file with the repositories spack package under test.
+3. Copy `build-ci/manifests` and put it under `.github/build-ci/manifests`. Note that adding additional manifests is the repository's maintainers responsibility.
+4. Open a PR with those changes, and the CI will run!
 
 > [!NOTE]
 > For Post-CI jobs for matrices, you will need to use the `job-output-artifact-pattern` to download all artifacts as part of that run, and then `jq` through the list of files to aggregate the data for your own purposes. This is due to GitHub overwriting the value of the matrix job output with the most recent completed instance of the matrix job, rather than all jobs.

--- a/model-component-ci-templates/README.md
+++ b/model-component-ci-templates/README.md
@@ -1,0 +1,33 @@
+# Example Templates for Model Component Repository Build CI
+
+## Overview
+
+For simple model component repository (MCR) build CI, it can often be enough to just run the defaults for the reusable workflow.
+
+More complex CI is definitely possible, and the basic examples here shouldn't limit more complex use cases - this is just for quick additions to MCRs.
+
+## Examples
+
+> [!NOTE]
+> Note that the name of the package that needs to be tested (`{{ package }}`), must be updated in the datafile at `.github/build-ci/data/standard.json`.
+
+Despite not being in these examples, Post-CI jobs can be created that make use of [a slew of outputs](./../.github/workflows/README.md#outputs) from the workflow.
+
+### Basic CI
+
+The simplest use case - a single manifest with no customisation, single compiler already in the upstream, and the default branch for `spack-config` and `spack-packages`. We get the definitions from the `.github/build-ci/data/standard.json` Jinja data file.
+
+Further constraints can be added in the `spack.packages.PACKAGE.require` section, or on the spec itself.
+
+For this case, you will use the `basic-ci.yml` and everything under `build-ci`.
+
+### Matrix CI
+
+A common but simple use case - multiple manifests under `.github/build-ci/manifests` that need to be tested in parallel - for example, multiple compilers, different variants, etc.
+
+There is no template for these manifests, as they will be down to the MCR maintainers discretion.
+
+For this case, you will use the `matrix-ci.yml` and everything under `build-ci`.
+
+> [!NOTE]
+> For Post-CI jobs for matrices, you will need to use the `job-output-artifact-pattern` to download all artifacts as part of that run, and then `jq` through the list of files to aggregate the data for your own purposes. This is due to GitHub overwriting the value of the matrix job output with the most recent completed instance of the matrix job, rather than all jobs.

--- a/model-component-ci-templates/README.md
+++ b/model-component-ci-templates/README.md
@@ -1,8 +1,8 @@
-# Example Templates for Model Component Repository Build CI
+# Example Templates for Repository Build CI
 
 ## Overview
 
-For simple model component repository (MCR) build CI, it can often be enough to just run the defaults for the reusable workflow.
+For simple repository build CI, including Model Component Repositories (MCRs) and any other repositories that are referenced in spack packages, it can often be enough to just run the defaults for the reusable workflow.
 
 More complex CI is definitely possible, and the basic examples here shouldn't limit more complex use cases - this is just for quick additions to MCRs.
 

--- a/model-component-ci-templates/build-ci/data/standard.json
+++ b/model-component-ci-templates/build-ci/data/standard.json
@@ -1,4 +1,5 @@
 {
     "package": "YOUR_PACKAGE_HERE",
-    "compiler": "intel@2021.10.0"
+    "compiler": "intel@2021.10.0",
+    "target": "x86_64"
 }

--- a/model-component-ci-templates/build-ci/data/standard.json
+++ b/model-component-ci-templates/build-ci/data/standard.json
@@ -1,0 +1,4 @@
+{
+    "package": "YOUR_PACKAGE_HERE",
+    "compiler": "intel@2021.10.0"
+}

--- a/model-component-ci-templates/build-ci/manifests/spack.yaml.j2
+++ b/model-component-ci-templates/build-ci/manifests/spack.yaml.j2
@@ -1,0 +1,6 @@
+spack:
+  specs:
+  - '{{ package }}@git.{{ ref }} {{ compiler }}'
+  concretizer:
+    unify: false
+  view: false

--- a/model-component-ci-templates/build-ci/manifests/spack.yaml.j2
+++ b/model-component-ci-templates/build-ci/manifests/spack.yaml.j2
@@ -1,10 +1,11 @@
+# package, compiler and target are defined in .github/build-ci/data/standard.json
 spack:
   specs:
   - '{{ package }}@git.{{ ref }}'
   packages:
     all:
       require:
-      - '%{{ compiler }} target=x86_64'
+      - '%{{ compiler }} target={{ target }}'
   concretizer:
     unify: false
   view: false

--- a/model-component-ci-templates/build-ci/manifests/spack.yaml.j2
+++ b/model-component-ci-templates/build-ci/manifests/spack.yaml.j2
@@ -1,6 +1,10 @@
 spack:
   specs:
-  - '{{ package }}@git.{{ ref }} {{ compiler }}'
+  - '{{ package }}@git.{{ ref }}'
+  packages:
+    all:
+      require:
+      - '%{{ compiler }} target=x86_64'
   concretizer:
     unify: false
   view: false

--- a/model-component-ci-templates/workflows/basic-ci.yml
+++ b/model-component-ci-templates/workflows/basic-ci.yml
@@ -9,6 +9,7 @@ jobs:
       spack-manifest-path: .github/build-ci/manifests/spack.yaml.j2
       spack-data-path: .github/build-ci/data/standard.json
       allow-ssh-into-spack-install: false  # If true, PR author must ssh into instance to complete job
+      # Below are the the effective defaults for some of the important inputs
       # spack-packages-ref: main
       # spack-config-ref: main
       # spack-ref: releases/v0.22

--- a/model-component-ci-templates/workflows/basic-ci.yml
+++ b/model-component-ci-templates/workflows/basic-ci.yml
@@ -1,0 +1,14 @@
+name: Build
+on:
+  pull_request:
+jobs:
+  ci:
+    name: CI
+    uses: access-nri/build-ci/.github/workflows/ci.yml@v2
+    with:
+      spack-manifest-path: .github/build-ci/manifests/spack.yaml.j2
+      spack-data-path: .github/build-ci/data/standard.json
+      allow-ssh-into-spack-install: false  # If true, PR author must ssh into instance to complete job
+      # spack-packages-ref: main
+      # spack-config-ref: main
+      # spack-ref: releases/v0.22

--- a/model-component-ci-templates/workflows/matrix-ci.yml
+++ b/model-component-ci-templates/workflows/matrix-ci.yml
@@ -15,7 +15,7 @@ jobs:
         # Find all relevant files under .github/build-ci/manifests
         # then output them as a JSON array (minus the last comma)
         run: |
-          files =$(find .github/build-ci/manifests/ -iname '*.j2' -printf '%p,')
+          files =$(find .github/build-ci/manifests/ -iname '*.j2' -printf '"%p",')
           echo "matrix=[${files%,}]" >> $GITHUB_OUTPUT
 
   ci:

--- a/model-component-ci-templates/workflows/matrix-ci.yml
+++ b/model-component-ci-templates/workflows/matrix-ci.yml
@@ -31,6 +31,7 @@ jobs:
       spack-manifest-path: ${{ matrix.file }}
       spack-data-path: .github/build-ci/data/standard.json
       allow-ssh-into-spack-install: false  # If true, PR author must ssh into instance to complete job
+      # Below are the the effective defaults for some of the important inputs
       # spack-packages-ref: main
       # spack-config-ref: main
       # spack-ref: releases/v0.22

--- a/model-component-ci-templates/workflows/matrix-ci.yml
+++ b/model-component-ci-templates/workflows/matrix-ci.yml
@@ -1,0 +1,36 @@
+name: Build
+on:
+  pull_request:
+jobs:
+  pre-ci:
+    name: Pre-CI
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up matrix
+        id: set-matrix
+        # Find all relevant files under .github/build-ci/manifests
+        # then output them as a JSON array (minus the last comma)
+        run: |
+          files =$(find .github/build-ci/manifests/ -iname '*.j2' -printf '%p,')
+          echo "matrix=[${files%,}]" >> $GITHUB_OUTPUT
+
+  ci:
+    name: CI
+    needs: pre-ci
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        file: ${{ fromJson(needs.pre-ci.outputs.matrix) }}
+    uses: access-nri/build-ci/.github/workflows/ci.yml@v2
+    with:
+      spack-manifest-path: ${{ matrix.file }}
+      spack-data-path: .github/build-ci/data/standard.json
+      allow-ssh-into-spack-install: false  # If true, PR author must ssh into instance to complete job
+      # spack-packages-ref: main
+      # spack-config-ref: main
+      # spack-ref: releases/v0.22


### PR DESCRIPTION
Closes #226

## Background

Rather than rewriting the same manifests and CI for every MCR, add some basic templates that can be used out of the box by MCRs. 

Note that these are basic examples and more complex CI should be created for MCRs as required by use case. 

## This PR

- **Add basic template for MCRs for single and matrix invocations**
- **Update README to note templates, and the existence of `ci-github-hosted.yml`**
