### PR TITLE
Upload Build Logs As Artifact

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -47,6 +47,8 @@ This workflow handles building and running short CI tests on a given spack manif
 | `spack-files-artifact-url` | `string` (URL) | The URL of the spack manifest and lock files artifact | `"https://github.com/ACCESS-NRI/MOM5/actions/runs/15890554355/artifacts/3406449135"` |
 | `job-output-artifact-pattern` | `string` (glob) | Wildcard pattern to match all job output artifacts across a matrix job | `'job-output-*'` |
 | `job-output-artifact-url` | `string` (URL) | The URL of the job output artifact, which contains the job outputs in JSON format | `"https://github.com/ACCESS-NRI/MOM5/actions/runs/15890554355/artifacts/3406449136"` |
+| `spack-logs-artifact-pattern` | `string` (glob) | Wildcard pattern to match all spack log artifacts across a matrix job | `'spack-logs-*'` |
+| `spack-logs-artifact-url` | `string` (URL) | The URL of the spack logs artifact, which contains the spack logs for each input spec | `"https://github.com/ACCESS-NRI/MOM5/actions/runs/15890554355/artifacts/3406449137"` |
 
 #### Future Outputs
 

--- a/.github/workflows/ci-github-hosted.yml
+++ b/.github/workflows/ci-github-hosted.yml
@@ -303,13 +303,15 @@ jobs:
           mkdir logs
 
           # Get all the top-level specs from the manifest
-          specs="$(yq '.spack.specs[] | match("[^%+~@ ]+").string' ${{ steps.env.outputs.spack-env-dir }}/default/spack.yaml)"
-          echo "Found top-level specs: $specs"
+          specs="$(yq '.spack.specs[]' ${{ steps.env.outputs.spack-env-dir }}/default/spack.yaml)"
+          echo "Found top-level specs:"
+          echo "$specs"
 
-          for spec in $specs; do
-            spec_no_space=$(tr ' ' '_' <<< "$spec")
+          while read -r spec; do
+            # We don't like spaces or unnecessary slashes in paths
+            spec_no_space=$(tr ' /' '__' <<< "$spec")
             spack -e default logs $spec > "logs/$spec_no_space.log"
-          done
+          done <<< "$specs"
 
       - name: Manifest - Logs Upload
         if: always() && (steps.install.conclusion == 'failure' || steps.install.conclusion == 'success')

--- a/.github/workflows/ci-github-hosted.yml
+++ b/.github/workflows/ci-github-hosted.yml
@@ -132,6 +132,14 @@ on:
         value: ${{ jobs.spack-install-and-test.outputs.job-output-artifact-url }}
         description: |
           The URL of the job output artifact, which contains the job outputs in JSON format.
+      spack-logs-artifact-pattern:
+        value: ${{ jobs.spack-install-and-test.outputs.spack-logs-artifact-pattern }}
+        description: |
+          Wildcard pattern to match all spack log artifacts across a matrix job.
+      spack-logs-artifact-url:
+        value: ${{ jobs.spack-install-and-test.outputs.spack-logs-artifact-url }}
+        description: |
+          The URL of the spack log artifact, which contains the spack logs created.
       # test-artifact-url:
       #   value: ${{}}
       #   description: |
@@ -152,6 +160,8 @@ jobs:
       spack-files-artifact-url: ${{ steps.manifest-upload.outputs.artifact-url }}
       job-output-artifact-pattern: ${{ steps.env.outputs.job-output-artifact-pattern }}
       job-output-artifact-url: ${{ steps.output-upload.outputs.artifact-url }}
+      spack-logs-artifact-pattern: ${{ steps.env.outputs.spack-logs-artifact-pattern }}
+      spack-logs-artifact-url: ${{ steps.logs-upload.outputs.artifact-url }}
       container-id: ${{ steps.env.outputs.container-id }}
       # test-artifact-url: ${{ steps.test.outputs.artifact-url }}
     steps:
@@ -175,6 +185,9 @@ jobs:
 
           echo 'spack-files-artifact-name=spack-files-${{ job.container.id }}' >> $GITHUB_OUTPUT
           echo 'spack-files-artifact-pattern=spack-files-*' >> $GITHUB_OUTPUT
+
+          echo 'spack-logs-artifact-name=spack-logs-${{ job.container.id }}' >> $GITHUB_OUTPUT
+          echo 'spack-logs-artifact-pattern=spack-logs-*' >> $GITHUB_OUTPUT
 
           echo 'container-id=${{ job.container.id }}' >> $GITHUB_OUTPUT
 
@@ -281,6 +294,32 @@ jobs:
           path: ${{ steps.env.outputs.spack-env-dir }}/default/spack.*
           if-no-files-found: error
 
+      - name: Manifest - Logs Create
+        if: always() && (steps.install.conclusion == 'failure' || steps.install.conclusion == 'success')
+        id: logs-create
+        run: |
+          . ${{ steps.env.outputs.SPACK_ROOT }}/../spack-config/ci-spack-enable.bash
+
+          mkdir logs
+
+          # Get all the top-level specs from the manifest
+          specs="$(yq '.spack.specs[] | match("[^%+~@ ]+").string' ${{ steps.env.outputs.spack-env-dir }}/default/spack.yaml)"
+          echo "Found top-level specs: $specs"
+
+          for spec in $specs; do
+            spec_no_space=$(tr ' ' '_' <<< "$spec")
+            spack -e default logs $spec > "logs/$spec_no_space.log"
+          done
+
+      - name: Manifest - Logs Upload
+        if: always() && (steps.install.conclusion == 'failure' || steps.install.conclusion == 'success')
+        id: logs-upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.env.outputs.spack-logs-artifact-name }}
+          path: logs/*.log
+          if-no-files-found: warning
+
       - name: Tmate - Create session
         # Only create the session if the spack installation was attempted, and we want a tmate session
         if: >-
@@ -341,7 +380,9 @@ jobs:
             "container_id": "${{ steps.env.outputs.container-id }}",
             "spack_files_artifact_pattern": "${{ steps.env.outputs.spack-files-artifact-pattern }}",
             "spack_files_artifact_url": "${{ steps.manifest-upload.outputs.artifact-url }}",
-            "job_output_artifact_pattern": "${{ steps.env.outputs.job-output-artifact-pattern }}"
+            "job_output_artifact_pattern": "${{ steps.env.outputs.job-output-artifact-pattern }}",
+            "spack_logs_artifact_url": "${{ steps.logs-upload.outputs.artifact-url }}",
+            "spack_logs_artifact_pattern": "${{ steps.env.outputs.artifact-pattern }}"
           }' > ./${{ steps.env.outputs.job-output-artifact-name }}
 
       - name: Job Outputs - Upload

--- a/.github/workflows/ci-github-hosted.yml
+++ b/.github/workflows/ci-github-hosted.yml
@@ -115,6 +115,10 @@ on:
         value: ${{ jobs.spack-install-and-test.outputs.container-id }}
         description: |
           The ID of the container where the spack packages have been installed.
+      short-container-id:
+        value: ${{ jobs.spack-install-and-test.outputs.short-container-id }}
+        description: |
+          The short ID of the container where the spack packages have been installed - used for artifact disambiguation.
       ## These outputs contain information on data uploaded as artifacts
       spack-files-artifact-pattern:
         value: ${{ jobs.spack-install-and-test.outputs.spack-files-artifact-pattern }}
@@ -163,6 +167,7 @@ jobs:
       spack-logs-artifact-pattern: ${{ steps.env.outputs.spack-logs-artifact-pattern }}
       spack-logs-artifact-url: ${{ steps.logs-upload.outputs.artifact-url }}
       container-id: ${{ steps.env.outputs.container-id }}
+      short-container-id: ${{ steps.env.outputs.short-container-id }}
       # test-artifact-url: ${{ steps.test.outputs.artifact-url }}
     steps:
       - name: Export environment variables into GitHub Actions format
@@ -179,17 +184,21 @@ jobs:
           # The upload step later requires a non-relative path, hence the realpath
           echo "spack-env-dir=$(realpath $SPACK_ROOT/../environments)" >> $GITHUB_OUTPUT
 
+          container_id=${{ job.container.id }}
+          short_container_id=$(echo ${{ job.container.id }} | cut -c1-8)
+
           # We can only get the job.container.id after the container is started, so we set it as the file name here
-          echo "job-output-artifact-name=job-output-${{ job.container.id }}" >> $GITHUB_OUTPUT
-          echo 'job-output-artifact-pattern=job-output-*' >> $GITHUB_OUTPUT
+          echo "job-output-artifact-name=job-output-$short_container_id" >> $GITHUB_OUTPUT
+          echo "job-output-artifact-pattern=job-output-*" >> $GITHUB_OUTPUT
 
-          echo 'spack-files-artifact-name=spack-files-${{ job.container.id }}' >> $GITHUB_OUTPUT
-          echo 'spack-files-artifact-pattern=spack-files-*' >> $GITHUB_OUTPUT
+          echo "spack-files-artifact-name=spack-files-$short_container_id" >> $GITHUB_OUTPUT
+          echo "spack-files-artifact-pattern=spack-files-*" >> $GITHUB_OUTPUT
 
-          echo 'spack-logs-artifact-name=spack-logs-${{ job.container.id }}' >> $GITHUB_OUTPUT
-          echo 'spack-logs-artifact-pattern=spack-logs-*' >> $GITHUB_OUTPUT
+          echo "spack-logs-artifact-name=spack-logs-$short_container_id" >> $GITHUB_OUTPUT
+          echo "spack-logs-artifact-pattern=spack-logs-*" >> $GITHUB_OUTPUT
 
-          echo 'container-id=${{ job.container.id }}' >> $GITHUB_OUTPUT
+          echo "container-id=$container_id" >> $GITHUB_OUTPUT
+          echo "short-container-id=$short_container_id" >> $GITHUB_OUTPUT
 
       - name: Update spack-package version
         id: spack-packages-update
@@ -307,10 +316,10 @@ jobs:
           echo "Found top-level specs:"
           echo "$specs"
 
+          i=0
           while read -r spec; do
-            # We don't like spaces or unnecessary slashes in paths
-            spec_no_space=$(tr ' /' '__' <<< "$spec")
-            spack -e default logs $spec > "logs/$spec_no_space.log"
+            spack -e default logs $spec > "logs/spec_${i}.log"
+            i=$((i + 1))
           done <<< "$specs"
 
       - name: Manifest - Logs Upload
@@ -320,7 +329,7 @@ jobs:
         with:
           name: ${{ steps.env.outputs.spack-logs-artifact-name }}
           path: logs/*.log
-          if-no-files-found: warning
+          if-no-files-found: warn
 
       - name: Tmate - Create session
         # Only create the session if the spack installation was attempted, and we want a tmate session
@@ -380,6 +389,7 @@ jobs:
             "spack_packages_sha": "${{ steps.spack-packages-update.outputs.sha }}",
             "sha": "${{ steps.checkout.outputs.commit }}",
             "container_id": "${{ steps.env.outputs.container-id }}",
+            "short_container_id": "${{ steps.env.outputs.short-container-id }}",
             "spack_files_artifact_pattern": "${{ steps.env.outputs.spack-files-artifact-pattern }}",
             "spack_files_artifact_url": "${{ steps.manifest-upload.outputs.artifact-url }}",
             "job_output_artifact_pattern": "${{ steps.env.outputs.job-output-artifact-pattern }}",

--- a/.github/workflows/ci-github-hosted.yml
+++ b/.github/workflows/ci-github-hosted.yml
@@ -185,7 +185,7 @@ jobs:
           echo "spack-env-dir=$(realpath $SPACK_ROOT/../environments)" >> $GITHUB_OUTPUT
 
           container_id=${{ job.container.id }}
-          short_container_id=$(echo ${{ job.container.id }} | cut -c1-8)
+          short_container_id=${container.id:0:8}
 
           # We can only get the job.container.id after the container is started, so we set it as the file name here
           echo "job-output-artifact-name=job-output-$short_container_id" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,10 @@ on:
         value: ${{ jobs.spack-install-and-test.outputs.container-id }}
         description: |
           The ID of the container where the spack packages have been installed.
+      short-container-id:
+        value: ${{ jobs.spack-install-and-test.outputs.short-container-id }}
+        description: |
+          The short ID of the container where the spack packages have been installed - used for artifact disambiguation.
       ## These outputs contain information on data uploaded as artifacts
       spack-files-artifact-pattern:
         value: ${{ jobs.spack-install-and-test.outputs.spack-files-artifact-pattern }}
@@ -167,6 +171,7 @@ jobs:
       spack-logs-artifact-pattern: ${{ steps.env.outputs.spack-logs-artifact-pattern }}
       spack-logs-artifact-url: ${{ steps.logs-upload.outputs.artifact-url }}
       container-id: ${{ steps.env.outputs.container-id }}
+      short-container-id: ${{ steps.env.outputs.short-container-id }}
       # test-artifact-url: ${{ steps.test.outputs.artifact-url }}
     steps:
       - name: Export environment variables into GitHub Actions format
@@ -183,17 +188,21 @@ jobs:
           # The upload step later requires a non-relative path, hence the realpath
           echo "spack-env-dir=$(realpath $SPACK_ROOT/../environments)" >> $GITHUB_OUTPUT
 
+          container_id=${{ job.container.id }}
+          short_container_id=$(echo ${{ job.container.id }} | cut -c1-8)
+
           # We can only get the job.container.id after the container is started, so we set it as the file name here
-          echo 'job-output-artifact-name=job-output-${{ job.container.id }}' >> $GITHUB_OUTPUT
-          echo 'job-output-artifact-pattern=job-output-*' >> $GITHUB_OUTPUT
+          echo "job-output-artifact-name=job-output-$short_container_id" >> $GITHUB_OUTPUT
+          echo "job-output-artifact-pattern=job-output-*" >> $GITHUB_OUTPUT
 
-          echo 'spack-files-artifact-name=spack-files-${{ job.container.id }}' >> $GITHUB_OUTPUT
-          echo 'spack-files-artifact-pattern=spack-files-*' >> $GITHUB_OUTPUT
+          echo "spack-files-artifact-name=spack-files-$short_container_id" >> $GITHUB_OUTPUT
+          echo "spack-files-artifact-pattern=spack-files-*" >> $GITHUB_OUTPUT
 
-          echo 'spack-logs-artifact-name=spack-logs-${{ job.container.id }}' >> $GITHUB_OUTPUT
-          echo 'spack-logs-artifact-pattern=spack-logs-*' >> $GITHUB_OUTPUT
+          echo "spack-logs-artifact-name=spack-logs-$short_container_id" >> $GITHUB_OUTPUT
+          echo "spack-logs-artifact-pattern=spack-logs-*" >> $GITHUB_OUTPUT
 
-          echo 'container-id=${{ job.container.id }}' >> $GITHUB_OUTPUT
+          echo "container-id=$container_id" >> $GITHUB_OUTPUT
+          echo "short-container-id=$short_container_id" >> $GITHUB_OUTPUT
 
       - name: Update spack-package version
         id: spack-packages-update
@@ -384,6 +393,7 @@ jobs:
             "spack_packages_sha": "${{ steps.spack-packages-update.outputs.sha }}",
             "sha": "${{ steps.checkout.outputs.commit }}",
             "container_id": "${{ steps.env.outputs.container-id }}",
+            "short_container_id": "${{ steps.env.outputs.short-container-id }}",
             "spack_files_artifact_pattern": "${{ steps.env.outputs.spack-files-artifact-pattern }}",
             "spack_files_artifact_url": "${{ steps.manifest-upload.outputs.artifact-url }}",
             "job_output_artifact_pattern": "${{ steps.env.outputs.job-output-artifact-pattern }}",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,7 +333,7 @@ jobs:
         with:
           name: ${{ steps.env.outputs.spack-logs-artifact-name }}
           path: logs/*.log
-          if-no-files-found: warning
+          if-no-files-found: warn
 
       - name: Tmate - Create session
         # Only create the session if the spack installation was attempted, and we want a tmate session

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,13 +307,15 @@ jobs:
           mkdir logs
 
           # Get all the top-level specs from the manifest
-          specs="$(yq '.spack.specs[] | match("[^%+~@ ]+").string' ${{ steps.env.outputs.spack-env-dir }}/default/spack.yaml)"
-          echo "Found top-level specs: $specs"
+          specs="$(yq '.spack.specs[]' ${{ steps.env.outputs.spack-env-dir }}/default/spack.yaml)"
+          echo "Found top-level specs:"
+          echo "$specs"
 
-          for spec in $specs; do
-            spec_no_space=$(tr ' ' '_' <<< "$spec")
-            spack -e default logs $spec > "logs/$spec_no_space.log"
-          done
+          while read -r spec; do
+            # We don't like spaces or unnecessary slashes in paths
+            spec_no_special_chars=$(tr ' /' '__' <<< "$spec")
+            spack -e default logs $spec > "logs/$spec_no_special_chars.log"
+          done <<< "$specs"
 
       - name: Manifest - Logs Upload
         if: always() && (steps.install.conclusion == 'failure' || steps.install.conclusion == 'success')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,14 @@ on:
         value: ${{ jobs.spack-install-and-test.outputs.job-output-artifact-url }}
         description: |
           The URL of the job output artifact, which contains the job outputs in JSON format.
+      spack-logs-artifact-pattern:
+        value: ${{ jobs.spack-install-and-test.outputs.spack-logs-artifact-pattern }}
+        description: |
+          Wildcard pattern to match all spack log artifacts across a matrix job.
+      spack-logs-artifact-url:
+        value: ${{ jobs.spack-install-and-test.outputs.spack-logs-artifact-url }}
+        description: |
+          The URL of the spack log artifact, which contains the spack logs created.
       # test-artifact-url:
       #   value: ${{}}
       #   description: |
@@ -156,6 +164,8 @@ jobs:
       spack-files-artifact-url: ${{ steps.manifest-upload.outputs.artifact-url }}
       job-output-artifact-pattern: ${{ steps.env.outputs.job-output-artifact-pattern }}
       job-output-artifact-url: ${{ steps.output-upload.outputs.artifact-url }}
+      spack-logs-artifact-pattern: ${{ steps.env.outputs.spack-logs-artifact-pattern }}
+      spack-logs-artifact-url: ${{ steps.logs-upload.outputs.artifact-url }}
       container-id: ${{ steps.env.outputs.container-id }}
       # test-artifact-url: ${{ steps.test.outputs.artifact-url }}
     steps:
@@ -179,6 +189,9 @@ jobs:
 
           echo 'spack-files-artifact-name=spack-files-${{ job.container.id }}' >> $GITHUB_OUTPUT
           echo 'spack-files-artifact-pattern=spack-files-*' >> $GITHUB_OUTPUT
+
+          echo 'spack-logs-artifact-name=spack-logs-${{ job.container.id }}' >> $GITHUB_OUTPUT
+          echo 'spack-logs-artifact-pattern=spack-logs-*' >> $GITHUB_OUTPUT
 
           echo 'container-id=${{ job.container.id }}' >> $GITHUB_OUTPUT
 
@@ -285,6 +298,32 @@ jobs:
           path: ${{ steps.env.outputs.spack-env-dir }}/default/spack.*
           if-no-files-found: error
 
+      - name: Manifest - Logs Create
+        if: always() && (steps.install.conclusion == 'failure' || steps.install.conclusion == 'success')
+        id: logs-create
+        run: |
+          . ${{ steps.env.outputs.SPACK_ROOT }}/../spack-config/ci-spack-enable.bash
+
+          mkdir logs
+
+          # Get all the top-level specs from the manifest
+          specs="$(yq '.spack.specs[] | match("[^%+~@ ]+").string' ${{ steps.env.outputs.spack-env-dir }}/default/spack.yaml)"
+          echo "Found top-level specs: $specs"
+
+          for spec in $specs; do
+            spec_no_space=$(tr ' ' '_' <<< "$spec")
+            spack -e default logs $spec > "logs/$spec_no_space.log"
+          done
+
+      - name: Manifest - Logs Upload
+        if: always() && (steps.install.conclusion == 'failure' || steps.install.conclusion == 'success')
+        id: logs-upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.env.outputs.spack-logs-artifact-name }}
+          path: logs/*.log
+          if-no-files-found: warning
+
       - name: Tmate - Create session
         # Only create the session if the spack installation was attempted, and we want a tmate session
         if: >-
@@ -345,7 +384,9 @@ jobs:
             "container_id": "${{ steps.env.outputs.container-id }}",
             "spack_files_artifact_pattern": "${{ steps.env.outputs.spack-files-artifact-pattern }}",
             "spack_files_artifact_url": "${{ steps.manifest-upload.outputs.artifact-url }}",
-            "job_output_artifact_pattern": "${{ steps.env.outputs.job-output-artifact-pattern }}"
+            "job_output_artifact_pattern": "${{ steps.env.outputs.job-output-artifact-pattern }}",
+            "spack_logs_artifact_url": "${{ steps.logs-upload.outputs.artifact-url }}",
+            "spack_logs_artifact_pattern": "${{ steps.env.outputs.artifact-pattern }}"
           }' > ./${{ steps.env.outputs.job-output-artifact-name }}
 
       - name: Job Outputs - Upload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,10 +320,10 @@ jobs:
           echo "Found top-level specs:"
           echo "$specs"
 
+          i=0
           while read -r spec; do
-            # We don't like spaces or unnecessary slashes in paths
-            spec_no_special_chars=$(tr ' /' '__' <<< "$spec")
-            spack -e default logs $spec > "logs/$spec_no_special_chars.log"
+            spack -e default logs $spec > "logs/spec_${i}.log"
+            i=$((i + 1))
           done <<< "$specs"
 
       - name: Manifest - Logs Upload


### PR DESCRIPTION
Closes #232

## Background

We need a middle ground between reading the spack logs from the workflow run, and sshing into the container to get the build logs. 

This PR uploads the build logs for each spec in `spack.specs` via `spack -e default logs SPEC`, as an artifact. 

It also shortens the container id to 8 characters for the purposes of shortening artifact file names. 

## The PR

- **Add upload of  `spack -e default logs SPEC` step for each input spec**
- **Add short container hash for files**
- **Add those changes from ci.yml to ci-github-hosted.yml**

## Testing

Testing done in run https://github.com/ACCESS-NRI/access-test-component/actions/runs/16895786859?pr=8, aka PR https://github.com/ACCESS-NRI/access-test-component/pull/8
