### PR TITLE
Relink `spack-config` -> Updated `spack` with appropriate config dir

### DIFF
--- a/.github/workflows/ci-github-hosted.yml
+++ b/.github/workflows/ci-github-hosted.yml
@@ -205,7 +205,7 @@ jobs:
         # Furthermore, if spack has been updated, we need to make sure we link to the correct vX config directory in spack-config.
         # We find what branch the spack SHA is part of, and attempt to link to that directory.
         run: |
-          spack_branch=$(git -C ${{ steps.env.outputs.SPACK_ROOT }}/../spack for-each-ref --format='%(refname:short)' refs/remotes --contains ${{ steps.spack-update.outputs.sha }} \
+          spack_branch=$(git -C ${{ steps.env.outputs.SPACK_ROOT }} for-each-ref --format='%(refname:short)' refs/remotes --contains ${{ steps.spack-update.outputs.sha }} \
             | grep origin/releases/ \
             | sed -E 's|^origin/releases/(.+)|\1|' \
           )
@@ -213,7 +213,7 @@ jobs:
           if [[ $(echo "$spack_branch" | wc -l) -gt 1 ]]; then
             echo "::error::${{ steps.spack-update.outputs.sha }} is part of multiple spack release branches, and we can't determine which to link spack-config to"
             exit 2
-          elif [[ -n "$spack_branch" ]]; then
+          elif [[ -z "$spack_branch" ]]; then
             echo "::error::${{ steps.spack-update.outputs.sha }} is not part of any spack release branch, so we can't link spack-config to anything"
             exit 2
           else

--- a/.github/workflows/ci-github-hosted.yml
+++ b/.github/workflows/ci-github-hosted.yml
@@ -180,21 +180,21 @@ jobs:
 
       - name: Update spack-package version
         id: spack-packages-update
-        uses: access-nri/build-ci/.github/actions/git-checkout-updated-ref@build-ci-2.0
+        uses: access-nri/build-ci/.github/actions/git-checkout-updated-ref@v2
         with:
           repository-path: ${{ steps.env.outputs.SPACK_ROOT }}/../spack-packages
           ref: ${{ inputs.spack-packages-ref }}
 
       - name: Update spack-config version
         id: spack-config-update
-        uses: access-nri/build-ci/.github/actions/git-checkout-updated-ref@build-ci-2.0
+        uses: access-nri/build-ci/.github/actions/git-checkout-updated-ref@v2
         with:
           repository-path: ${{ steps.env.outputs.SPACK_ROOT }}/../spack-config
           ref: ${{ inputs.spack-config-ref }}
 
       - name: Update spack version
         id: spack-update
-        uses: access-nri/build-ci/.github/actions/git-checkout-updated-ref@build-ci-2.0
+        uses: access-nri/build-ci/.github/actions/git-checkout-updated-ref@v2
         with:
           repository-path: ${{ steps.env.outputs.SPACK_ROOT }}
           ref: ${{ inputs.spack-ref }}

--- a/.github/workflows/ci-github-hosted.yml
+++ b/.github/workflows/ci-github-hosted.yml
@@ -220,7 +220,7 @@ jobs:
             echo "Linking spack with SHA ${{ steps.spack-update.outputs.sha }} to spack-config directory $spack_branch"
           fi
 
-          ln --symbolic --relative --verbose --force ${{ steps.env.outputs.SPACK_ROOT }}/${spack_branch}/* ${{ steps.env.outputs.SPACK_ROOT }}/etc/spack/
+          ln --symbolic --relative --verbose --force ${{ steps.env.outputs.SPACK_ROOT }}/../spack-config/${spack_branch}/* ${{ steps.env.outputs.SPACK_ROOT }}/etc/spack/
 
       - name: Spack - Initial Enable + Compiler Load
         run: |

--- a/.github/workflows/ci-github-hosted.yml
+++ b/.github/workflows/ci-github-hosted.yml
@@ -205,7 +205,7 @@ jobs:
         # Furthermore, if spack has been updated, we need to make sure we link to the correct vX config directory in spack-config.
         # We find what branch the spack SHA is part of, and attempt to link to that directory.
         run: |
-          spack_branch=$(git for-each-ref --format='%(refname:short)' refs/remotes --contains ${{ steps.spack-update.outputs.sha }} \
+          spack_branch=$(git -C ${{ steps.env.outputs.SPACK_ROOT }}/../spack for-each-ref --format='%(refname:short)' refs/remotes --contains ${{ steps.spack-update.outputs.sha }} \
             | grep origin/releases/ \
             | sed -E 's|^origin/releases/(.+)|\1|' \
           )

--- a/.github/workflows/ci-github-hosted.yml
+++ b/.github/workflows/ci-github-hosted.yml
@@ -201,7 +201,26 @@ jobs:
 
       - name: Relink spack-config to spack
         if: steps.spack-config-update.outputs.updated == 'true' || steps.spack-update.outputs.updated == 'true'
-        run: ln --symbolic --relative --verbose --force ${{ steps.env.outputs.SPACK_CONFIG_DIR }}/* ${{ steps.env.outputs.SPACK_ROOT }}/etc/spack/
+        # If there was a change in spack or spack-config, we should relink the config to spack.
+        # Furthermore, if spack has been updated, we need to make sure we link to the correct vX config directory in spack-config.
+        # We find what branch the spack SHA is part of, and attempt to link to that directory.
+        run: |
+          spack_branch=$(git for-each-ref --format='%(refname:short)' refs/remotes --contains ${{ steps.spack-update.outputs.sha }}
+            | grep origin/releases/
+            | sed -E 's|^origin/releases/(.+)|\1|'
+          )
+
+          if [[ $(echo "$spack_branch" | wc -l) -gt 1 ]]; then
+            echo "::error::${{ steps.spack-update.outputs.sha }} is part of multiple spack release branches, and we can't determine which to link spack-config to"
+            exit 2
+          elif [[ -n "$spack_branch" ]]; then
+            echo "::error::${{ steps.spack-update.outputs.sha }} is not part of any spack release branch, so we can't link spack-config to anything"
+            exit 2
+          else
+            echo "Linking spack with SHA ${{ steps.spack-update.outputs.sha }} to spack-config directory $spack_branch"
+          fi
+
+          ln --symbolic --relative --verbose --force ${{ steps.env.outputs.SPACK_ROOT }}/${spack_branch}/* ${{ steps.env.outputs.SPACK_ROOT }}/etc/spack/
 
       - name: Spack - Initial Enable + Compiler Load
         run: |

--- a/.github/workflows/ci-github-hosted.yml
+++ b/.github/workflows/ci-github-hosted.yml
@@ -205,9 +205,9 @@ jobs:
         # Furthermore, if spack has been updated, we need to make sure we link to the correct vX config directory in spack-config.
         # We find what branch the spack SHA is part of, and attempt to link to that directory.
         run: |
-          spack_branch=$(git for-each-ref --format='%(refname:short)' refs/remotes --contains ${{ steps.spack-update.outputs.sha }}
-            | grep origin/releases/
-            | sed -E 's|^origin/releases/(.+)|\1|'
+          spack_branch=$(git for-each-ref --format='%(refname:short)' refs/remotes --contains ${{ steps.spack-update.outputs.sha }} \
+            | grep origin/releases/ \
+            | sed -E 's|^origin/releases/(.+)|\1|' \
           )
 
           if [[ $(echo "$spack_branch" | wc -l) -gt 1 ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
         # Furthermore, if spack has been updated, we need to make sure we link to the correct vX config directory in spack-config.
         # We find what branch the spack SHA is part of, and attempt to link to that directory.
         run: |
-          spack_branch=$(git -C ${{ steps.env.outputs.SPACK_ROOT }}/../spack for-each-ref --format='%(refname:short)' refs/remotes --contains ${{ steps.spack-update.outputs.sha }} \
+          spack_branch=$(git -C ${{ steps.env.outputs.SPACK_ROOT }} for-each-ref --format='%(refname:short)' refs/remotes --contains ${{ steps.spack-update.outputs.sha }} \
             | grep origin/releases/ \
             | sed -E 's|^origin/releases/(.+)|\1|' \
           )
@@ -217,7 +217,7 @@ jobs:
           if [[ $(echo "$spack_branch" | wc -l) -gt 1 ]]; then
             echo "::error::${{ steps.spack-update.outputs.sha }} is part of multiple spack release branches, and we can't determine which to link spack-config to"
             exit 2
-          elif [[ -n "$spack_branch" ]]; then
+          elif [[ -z "$spack_branch" ]]; then
             echo "::error::${{ steps.spack-update.outputs.sha }} is not part of any spack release branch, so we can't link spack-config to anything"
             exit 2
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,9 +209,9 @@ jobs:
         # Furthermore, if spack has been updated, we need to make sure we link to the correct vX config directory in spack-config.
         # We find what branch the spack SHA is part of, and attempt to link to that directory.
         run: |
-          spack_branch=$(git for-each-ref --format='%(refname:short)' refs/remotes --contains ${{ steps.spack-update.outputs.sha }}
-            | grep origin/releases/
-            | sed -E 's|^origin/releases/(.+)|\1|'
+          spack_branch=$(git for-each-ref --format='%(refname:short)' refs/remotes --contains ${{ steps.spack-update.outputs.sha }} \
+            | grep origin/releases/ \
+            | sed -E 's|^origin/releases/(.+)|\1|' \
           )
 
           if [[ $(echo "$spack_branch" | wc -l) -gt 1 ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
         # Furthermore, if spack has been updated, we need to make sure we link to the correct vX config directory in spack-config.
         # We find what branch the spack SHA is part of, and attempt to link to that directory.
         run: |
-          spack_branch=$(git for-each-ref --format='%(refname:short)' refs/remotes --contains ${{ steps.spack-update.outputs.sha }} \
+          spack_branch=$(git -C ${{ steps.env.outputs.SPACK_ROOT }}/../spack for-each-ref --format='%(refname:short)' refs/remotes --contains ${{ steps.spack-update.outputs.sha }} \
             | grep origin/releases/ \
             | sed -E 's|^origin/releases/(.+)|\1|' \
           )

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,28 +184,47 @@ jobs:
 
       - name: Update spack-package version
         id: spack-packages-update
-        uses: access-nri/build-ci/.github/actions/git-checkout-updated-ref@build-ci-2.0
+        uses: access-nri/build-ci/.github/actions/git-checkout-updated-ref@v2
         with:
           repository-path: ${{ steps.env.outputs.SPACK_ROOT }}/../spack-packages
           ref: ${{ inputs.spack-packages-ref }}
 
       - name: Update spack-config version
         id: spack-config-update
-        uses: access-nri/build-ci/.github/actions/git-checkout-updated-ref@build-ci-2.0
+        uses: access-nri/build-ci/.github/actions/git-checkout-updated-ref@v2
         with:
           repository-path: ${{ steps.env.outputs.SPACK_ROOT }}/../spack-config
           ref: ${{ inputs.spack-config-ref }}
 
       - name: Update spack version
         id: spack-update
-        uses: access-nri/build-ci/.github/actions/git-checkout-updated-ref@build-ci-2.0
+        uses: access-nri/build-ci/.github/actions/git-checkout-updated-ref@v2
         with:
           repository-path: ${{ steps.env.outputs.SPACK_ROOT }}
           ref: ${{ inputs.spack-ref }}
 
       - name: Relink spack-config to spack
         if: steps.spack-config-update.outputs.updated == 'true' || steps.spack-update.outputs.updated == 'true'
-        run: ln --symbolic --relative --verbose --force ${{ steps.env.outputs.SPACK_CONFIG_DIR }}/* ${{ steps.env.outputs.SPACK_ROOT }}/etc/spack/
+        # If there was a change in spack or spack-config, we should relink the config to spack.
+        # Furthermore, if spack has been updated, we need to make sure we link to the correct vX config directory in spack-config.
+        # We find what branch the spack SHA is part of, and attempt to link to that directory.
+        run: |
+          spack_branch=$(git for-each-ref --format='%(refname:short)' refs/remotes --contains ${{ steps.spack-update.outputs.sha }}
+            | grep origin/releases/
+            | sed -E 's|^origin/releases/(.+)|\1|'
+          )
+
+          if [[ $(echo "$spack_branch" | wc -l) -gt 1 ]]; then
+            echo "::error::${{ steps.spack-update.outputs.sha }} is part of multiple spack release branches, and we can't determine which to link spack-config to"
+            exit 2
+          elif [[ -n "$spack_branch" ]]; then
+            echo "::error::${{ steps.spack-update.outputs.sha }} is not part of any spack release branch, so we can't link spack-config to anything"
+            exit 2
+          else
+            echo "Linking spack with SHA ${{ steps.spack-update.outputs.sha }} to spack-config directory $spack_branch"
+          fi
+
+          ln --symbolic --relative --verbose --force ${{ steps.env.outputs.SPACK_ROOT }}/${spack_branch}/* ${{ steps.env.outputs.SPACK_ROOT }}/etc/spack/
 
       - name: Spack - Initial Enable + Compiler Load
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
             echo "Linking spack with SHA ${{ steps.spack-update.outputs.sha }} to spack-config directory $spack_branch"
           fi
 
-          ln --symbolic --relative --verbose --force ${{ steps.env.outputs.SPACK_ROOT }}/${spack_branch}/* ${{ steps.env.outputs.SPACK_ROOT }}/etc/spack/
+          ln --symbolic --relative --verbose --force ${{ steps.env.outputs.SPACK_ROOT }}/../spack-config/${spack_branch}/* ${{ steps.env.outputs.SPACK_ROOT }}/etc/spack/
 
       - name: Spack - Initial Enable + Compiler Load
         run: |


### PR DESCRIPTION
Closes #234

## Background

Users have tried updating their `spack` to `1.0`, but to relink `spack-config` to `spack` we always use the value of `SPACK_CONFIG_DIR`, which is set at build time. This means that we can attempt to link `v0.22` config to `v1.0`, which is bad. 

## The PR

This PR checks the ref that `spack` was updated to, then determines if that is part of a given `origin/releases/vX` branch, and then relinks `spack` to `spack-config` via the appropriate `vX` directory.

## Testing

Tested via https://github.com/ACCESS-NRI/access-test-component/pull/9

### Test default spack linking

Succeeded in run https://github.com/ACCESS-NRI/access-test-component/actions/runs/16922975520/job/47953036403#step:7:20

### Test `HEAD` of `releases/v0.23` linking

Succeeded in run https://github.com/ACCESS-NRI/access-test-component/actions/runs/16923099192/job/47953409130#step:7:20 - cancelled rest of the run to save time

### Test commit within `releases/v1.0` linking

Succeeded in run https://github.com/ACCESS-NRI/access-test-component/actions/runs/16923169567/job/47953615479#step:7:20 - rest of run failed due to wrong `spack-packages` version used