### PR TITLE
Logs Upload Fix

### DIFF
--- a/.github/workflows/ci-github-hosted.yml
+++ b/.github/workflows/ci-github-hosted.yml
@@ -336,7 +336,7 @@ jobs:
           fi
 
           # Get all the top-level specs from the manifest
-          specs="$(yq '.roots[].spec' ${{ steps.env.outputs.spack-env-dir }}/default/spack.lock)"
+          specs="$(jq --raw-output '.roots[].spec' ${{ steps.env.outputs.spack-env-dir }}/default/spack.lock)"
           echo "Found top-level specs:"
           echo "$specs"
 

--- a/.github/workflows/ci-github-hosted.yml
+++ b/.github/workflows/ci-github-hosted.yml
@@ -330,8 +330,13 @@ jobs:
 
           mkdir logs
 
+          if [ ! -f ${{ steps.env.outputs.spack-env-dir }}/default/spack.lock ]; then
+            echo "Spack lock file not found, skipping log creation."
+            exit 0
+          fi
+
           # Get all the top-level specs from the manifest
-          specs="$(yq '.spack.specs[]' ${{ steps.env.outputs.spack-env-dir }}/default/spack.yaml)"
+          specs="$(yq '.roots[].spec' ${{ steps.env.outputs.spack-env-dir }}/default/spack.lock)"
           echo "Found top-level specs:"
           echo "$specs"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,7 +340,7 @@ jobs:
           fi
 
           # Get all the top-level specs from the manifest
-          specs="$(yq '.roots[].spec' ${{ steps.env.outputs.spack-env-dir }}/default/spack.lock)"
+          specs="$(jq --raw-output '.roots[].spec' ${{ steps.env.outputs.spack-env-dir }}/default/spack.lock)"
           echo "Found top-level specs:"
           echo "$specs"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,8 +334,13 @@ jobs:
 
           mkdir logs
 
+          if [ ! -f ${{ steps.env.outputs.spack-env-dir }}/default/spack.lock ]; then
+            echo "Spack lock file not found, skipping log creation."
+            exit 0
+          fi
+
           # Get all the top-level specs from the manifest
-          specs="$(yq '.spack.specs[]' ${{ steps.env.outputs.spack-env-dir }}/default/spack.yaml)"
+          specs="$(yq '.roots[].spec' ${{ steps.env.outputs.spack-env-dir }}/default/spack.lock)"
           echo "Found top-level specs:"
           echo "$specs"
 

--- a/containers/upstream/prod/packages.spack.yaml
+++ b/containers/upstream/prod/packages.spack.yaml
@@ -13,6 +13,7 @@ spack:
     - compilers:
       - intel@2021.10.0
       - oneapi@2025.2.0
+      - gcc@13.2.0
 
     # Targets for the packages
     - targets:


### PR DESCRIPTION
Closes #236

## Background

To upload the logs in `spack -e default logs SPEC`, we get the specs via `jq '.spack.specs[]`. This works fine for simple manifests that are simply a list of specs, but doesn't work for speclists that contain matrices or definitions. 

Instead, we interrogate the `spack.lock` file, which contains information on the concretized result (eg. with the matrices and definitions applied). I note that all versions of the `spack.lock` file have the `jq '.roots[].spec'` construct, which give a list of abstract specs after application of matrices and definitions. We can use this instead. 

And as a bonus, I create a new upstream image definition that installs common packages for `%gcc@13.2.0`. 

## The PR

- **Use spack.lock to find root specs**
- **Add packages to install for %gcc@13.2.0**

## Testing

Tested on multiple manifest types, in the `ghcr.io/ACCESS-NRI/build-ci-upstream:rocky-2025.08.000` image. Tests follow:

### Simple manifest

```yaml
spack:
  specs:
  - datetime-fortran%gcc
  - datetime-fortran%intel
  view: false
  concretizer:
    unify: false
```

Result of `jq -r '.roots[].spec' spack.lock`:

```
datetime-fortran%gcc
datetime-fortran%intel
```

### Matrix manfiest

```yaml
spack:
  specs:
  - matrix:
    - ['datetime-fortran']
    - ['%gcc', '%intel']
  view: false
  concretizer:
    unify: false
```

Result of `jq -r '.roots[].spec' spack.lock`:

```
datetime-fortran%gcc
datetime-fortran%intel
```

### Definition manifest

```yaml
spack:
  definitions:
  - defs:
    - matrix:
      - ['datetime-fortran']
      - ['%intel', '%gcc']
      - ['target=x86_64']
  specs:
  - $defs
  view: false
  concretizer:
    unify: false
```

Result of `jq -r '.roots[].spec' spack.lock`:

```
datetime-fortran%intel arch=None-None-x86_64
datetime-fortran%gcc arch=None-None-x86_64
```
