### PR TITLE
Dockerfile.base-spack: support Spack v1.0 by reordering target

### DIFF
--- a/containers/Dockerfile.base-spack
+++ b/containers/Dockerfile.base-spack
@@ -215,14 +215,14 @@ spack load ${COMPILER_PKG_NAME}@${COMPILER_PKG_VERSION} \
  && spack compiler find
 
 spack install \
-    gmake %${COMPILER_NAME}@${COMPILER_VERSION} target=${SPACK_TARGET}
+    gmake target=${SPACK_TARGET} %${COMPILER_NAME}@${COMPILER_VERSION}
 
 spack install \
-    cmake %${COMPILER_NAME}@${COMPILER_VERSION} target=${SPACK_TARGET}
+    cmake target=${SPACK_TARGET} %${COMPILER_NAME}@${COMPILER_VERSION}
 
 spack install \
-    ${MPI_NAME}@${MPI_VERSION} %${COMPILER_NAME}@${COMPILER_VERSION} \
-    target=${SPACK_TARGET}
+    ${MPI_NAME}@${MPI_VERSION} target=${SPACK_TARGET} \
+    %${COMPILER_NAME}@${COMPILER_VERSION}
 
 spack clean --downloads
 EOF


### PR DESCRIPTION
Spack v1.0 requires a specific ordering of variants and compilers: https://github.com/spack/spack/releases/tag/v1.0.0#ordering-of-variants-and-compilers-now-matters