### PR TITLE
Dockerfile.base-spack: enable local config

### DIFF
--- a/containers/Dockerfile.base-spack
+++ b/containers/Dockerfile.base-spack
@@ -129,7 +129,6 @@ ENV ENV_COMPILER_VERSION=${COMPILER_VERSION}
 # TODO: Ideally we want spack-enable.bash to be the only source of these
 #       definitions. See if spack-enable.bash can be used instead.
 # NOTE: In the meantime, keep in-sync with spack-config/spack-enable.bash
-ENV SPACK_DISABLE_LOCAL_CONFIG="true"
 ENV SPACK_USER_CACHE_PATH=${SPACK_ROOT}/..
 
 LABEL au.org.access-nri.image.spack-repo-version ${SPACK_REPO_VERSION}


### PR DESCRIPTION
Closes: #240
Spack v1.0 tracks compilers as packages. If `SPACK_DISABLE_LOCAL_CONFIG="true"` is set, when compilers are found they are added to `/opt/spack/etc/spack/packages.yaml`. By not setting `SPACK_DISABLE_LOCAL_CONFIG="true"`, the compilers are added to `~/.spack/packages.yaml`. This avoids the Spack compilers being lost if a different version of the `spack-config` repository is checked out.

### Testing

```
[root@9a0e63775bb5 spack]# cat /opt/spack/etc/spack/packages.yaml 
packages:
  perl:
    externals:
    - spec: perl@5.26.3
      prefix: /usr
    buildable: false
  cmake:
    # Syntax for requirement:
    require:
    - one_of:
      - "@3.31.6"  # v1.0 spack
      - "@3.24.4"  # v0.22 spack
    # Syntax for preference:
    #version: [3.31.6, 3.24.4]
  libtool:
    version: [:2.4.6]
```
```
[root@9a0e63775bb5 spack]# cat ~/.spack/packages.yaml 
packages:
  intel-oneapi-compilers:
    externals:
    - spec: intel-oneapi-compilers@2023.2.4
      prefix: /opt/release/linux-x86_64/intel-oneapi-compilers-2023.2.4-s7ejmkcvzo5sgvvspirvnym2pm6mcbi6
      extra_attributes:
        compilers:
          c: /opt/release/linux-x86_64/intel-oneapi-compilers-2023.2.4-s7ejmkcvzo5sgvvspirvnym2pm6mcbi6/compiler/2023.2.4/linux/bin/icx
          cxx: /opt/release/linux-x86_64/intel-oneapi-compilers-2023.2.4-s7ejmkcvzo5sgvvspirvnym2pm6mcbi6/compiler/2023.2.4/linux/bin/icpx
          fortran: /opt/release/linux-x86_64/intel-oneapi-compilers-2023.2.4-s7ejmkcvzo5sgvvspirvnym2pm6mcbi6/compiler/2023.2.4/linux/bin/ifx
  intel-oneapi-compilers-classic:
    externals:
    - spec: intel-oneapi-compilers-classic@2021.10.0
      prefix: /opt/release/linux-x86_64/intel-oneapi-compilers-2023.2.4-s7ejmkcvzo5sgvvspirvnym2pm6mcbi6/compiler/2023.2.4/linux
      extra_attributes:
        compilers:
          c: /opt/release/linux-x86_64/intel-oneapi-compilers-2023.2.4-s7ejmkcvzo5sgvvspirvnym2pm6mcbi6/compiler/2023.2.4/linux/bin/intel64/icc
          cxx: /opt/release/linux-x86_64/intel-oneapi-compilers-2023.2.4-s7ejmkcvzo5sgvvspirvnym2pm6mcbi6/compiler/2023.2.4/linux/bin/intel64/icpc
          fortran: /opt/release/linux-x86_64/intel-oneapi-compilers-2023.2.4-s7ejmkcvzo5sgvvspirvnym2pm6mcbi6/compiler/2023.2.4/linux/bin/intel64/ifort
  gcc:
    externals:
    - spec: gcc@8.5.0 languages:='c,c++,fortran'
      prefix: /usr
      extra_attributes:
        compilers:
          c: /usr/bin/gcc
          cxx: /usr/bin/g++
          fortran: /usr/bin/gfortran
```
