### PR TITLE
Scope both the local and OCI buildcaches to `system` rather than `user`

### DIFF
--- a/.github/workflows/ci-github-hosted.yml
+++ b/.github/workflows/ci-github-hosted.yml
@@ -273,7 +273,8 @@ jobs:
         if: inputs.spack-oci-buildcache-url != ''
         run: |
           . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
-          spack mirror add --unsigned \
+          spack mirror add --scope=system \
+            --unsigned \
             --oci-username-variable OCI_USERNAME \
             --oci-password-variable OCI_PASSWORD \
             oci_buildcache ${{ inputs.spack-oci-buildcache-url }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,8 @@ jobs:
         if: inputs.spack-oci-buildcache-url != ''
         run: |
           . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
-          spack mirror add --unsigned \
+          spack mirror add --scope=system \
+            --unsigned \
             --oci-username-variable OCI_USERNAME \
             --oci-password-variable OCI_PASSWORD \
             oci_buildcache ${{ inputs.spack-oci-buildcache-url }}

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -238,7 +238,7 @@ FROM base-spack AS runner
 LABEL org.opencontainers.image.source=https://github.com/ACCESS-NRI/build-ci
 
 # Set up ACCESS Spack buildcache
-RUN spack mirror add --autopush --unsigned runner_set_buildcache /opt/runner_set_buildcache
+RUN spack mirror add --scope=system --autopush --unsigned runner_set_buildcache /opt/runner_set_buildcache
 
 COPY ${SOURCE_COMPILERS_SPACK_MANIFEST} ${ENV_COMPILERS_SPACK_MANIFEST}
 COPY ${SOURCE_PACKAGES_SPACK_MANIFEST} ${ENV_PACKAGES_SPACK_MANIFEST}


### PR DESCRIPTION
Closes #243

## Background

For some reason `--scope=user` buildcaches are not persisted when running a container as `root` via GitHub Actions, even though they work locally in the container. 

The fix is to move the `spack mirror add` to the `--scope=system` level, rather than the `user` one. 


## The PR

* Update the scope while building the image to `system`, from `user`
* Also update the `oci`-backed buildcache scope to `system`, just to be consistent. 

## Testing

Tested via https://github.com/ACCESS-NRI/access-test-component/actions/runs/17453892656/job/49563693372?pr=12#step:14:1358 (in which you'll note the searching for buildcache items)
