### PR TITLE
Use Hashes for Spec Logs Generation

### DIFF
--- a/.github/workflows/ci-github-hosted.yml
+++ b/.github/workflows/ci-github-hosted.yml
@@ -384,16 +384,16 @@ jobs:
             exit 0
           fi
 
-          # Get all the top-level specs from the manifest
-          specs="$(jq --raw-output '.roots[].spec' ${{ steps.env.outputs.spack-env-dir }}/default/spack.lock)"
-          echo "Found top-level specs:"
-          echo "$specs"
+          # Get all the top-level hashes from the manifest
+          hashes="$(jq --raw-output '.roots[].hash' ${{ steps.env.outputs.spack-env-dir }}/default/spack.lock)"
+          echo "Found top-level hashes:"
+          echo "$hashes"
 
           i=0
-          while read -r spec; do
-            spack -e default logs $spec > "logs/spec_${i}.log"
+          while read -r hash; do
+            spack -e default logs /$hash > "logs/spec_${i}.log"
             i=$((i + 1))
-          done <<< "$specs"
+          done <<< "$hashes"
 
       - name: Manifest - Logs Upload
         if: always() && (steps.install.conclusion == 'failure' || steps.install.conclusion == 'success')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,16 +388,16 @@ jobs:
             exit 0
           fi
 
-          # Get all the top-level specs from the manifest
-          specs="$(jq --raw-output '.roots[].spec' ${{ steps.env.outputs.spack-env-dir }}/default/spack.lock)"
-          echo "Found top-level specs:"
-          echo "$specs"
+          # Get all the top-level hashes from the manifest
+          hashes="$(jq --raw-output '.roots[].hash' ${{ steps.env.outputs.spack-env-dir }}/default/spack.lock)"
+          echo "Found top-level hashes:"
+          echo "$hashes"
 
           i=0
-          while read -r spec; do
-            spack -e default logs $spec > "logs/spec_${i}.log"
+          while read -r hash; do
+            spack -e default logs /$hash > "logs/spec_${i}.log"
             i=$((i + 1))
-          done <<< "$specs"
+          done <<< "$hashes"
 
       - name: Manifest - Logs Upload
         if: always() && (steps.install.conclusion == 'failure' || steps.install.conclusion == 'success')


### PR DESCRIPTION
See https://github.com/ACCESS-NRI/access3-share/actions/runs/17455915051/job/49569374009, from https://github.com/ACCESS-NRI/access3-share/pull/11

## Background

Using specs for log generation has the possibility of failing due to spec definitions potentially being quite similar (see https://github.com/ACCESS-NRI/access3-share/pull/11/files#diff-9664d220045bd40cfb26c542411ad41aeab22c0d1334418d10d67757fdbd26bfR3-R4)

Instead of using the spec name, use the hash instead, which is unambiguous. 

## The PR

* `ci[-github-hosted].yml`: Replace generation of logs via spec name with spec hash


## Testing

Tested in `ghcr.io/access-nri/build-ci-upstream:rocky-2025.09.001`, by running https://github.com/ACCESS-NRI/access3-share/pull/11/files#diff-9664d220045bd40cfb26c542411ad41aeab22c0d1334418d10d67757fdbd26bf and then running:

https://github.com/ACCESS-NRI/build-ci/blob/1fe40b88f8821ce644174ae2afec64fa256a6015/.github/workflows/ci.yml#L392-L400 (subsituting the GitHub Actions Templating). 
