### PR TITLE
Load compilers via upstream lockfile

### DIFF
--- a/.github/workflows/ci-github-hosted.yml
+++ b/.github/workflows/ci-github-hosted.yml
@@ -262,11 +262,19 @@ jobs:
       - name: Spack - Initial Enable + Compiler Load
         run: |
           . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
-          yq '.spack.specs[]' "${ENV_COMPILERS_SPACK_MANIFEST}" | while read compiler; do
-            echo "Loading compiler: $compiler"
-            spack load $compiler
-            spack compiler find --scope=user
-          done
+
+          # Attempt a load of compilers via upstream compilers lockfile (if it exists)
+          if [ -f /opt/upstream/compilers.spack.lock ]; then
+            echo "Found /opt/upstream/compilers.spack.lock, attempting to load compilers from upstream"
+            yq '.roots[].hash' /opt/upstream/compilers.spack.lock | while read hash; do
+              echo "Loading compiler with hash: $hash"
+              spack load /$hash
+              spack compiler find --scope=user
+            done
+          else
+            echo "No /opt/upstream/compilers.spack.lock found, skipping compiler load from upstream"
+          fi
+
           spack find
 
       - name: Spack - OCI Buildcache Init

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,11 +266,19 @@ jobs:
       - name: Spack - Initial Enable + Compiler Load
         run: |
           . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
-          yq '.spack.specs[]' "${ENV_COMPILERS_SPACK_MANIFEST}" | while read compiler; do
-            echo "Loading compiler: $compiler"
-            spack load $compiler
-            spack compiler find --scope=user
-          done
+
+          # Attempt a load of compilers via upstream compilers lockfile (if it exists)
+          if [ -f /opt/upstream/compilers.spack.lock ]; then
+            echo "Found /opt/upstream/compilers.spack.lock, attempting to load compilers from upstream"
+            yq '.roots[].hash' /opt/upstream/compilers.spack.lock | while read hash; do
+              echo "Loading compiler with hash: $hash"
+              spack load /$hash
+              spack compiler find --scope=user
+            done
+          else
+            echo "No /opt/upstream/compilers.spack.lock found, skipping compiler load from upstream"
+          fi
+
           spack find
 
       - name: Spack - OCI Buildcache Init

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -240,5 +240,8 @@ LABEL org.opencontainers.image.source=https://github.com/ACCESS-NRI/build-ci
 # Set up ACCESS Spack buildcache
 RUN spack mirror add --scope=system --autopush --unsigned runner_set_buildcache /opt/runner_set_buildcache
 
+# Bootstrap Spack now to avoid doing it on first runner use, every time
+RUN spack bootstrap now
+
 ENTRYPOINT ["/bin/bash", "/opt/spack/share/spack/docker/entrypoint.bash"]
 CMD ["interactive-shell"]

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -240,8 +240,5 @@ LABEL org.opencontainers.image.source=https://github.com/ACCESS-NRI/build-ci
 # Set up ACCESS Spack buildcache
 RUN spack mirror add --scope=system --autopush --unsigned runner_set_buildcache /opt/runner_set_buildcache
 
-COPY ${SOURCE_COMPILERS_SPACK_MANIFEST} ${ENV_COMPILERS_SPACK_MANIFEST}
-COPY ${SOURCE_PACKAGES_SPACK_MANIFEST} ${ENV_PACKAGES_SPACK_MANIFEST}
-
 ENTRYPOINT ["/bin/bash", "/opt/spack/share/spack/docker/entrypoint.bash"]
 CMD ["interactive-shell"]


### PR DESCRIPTION
## Background

Currently, we load compilers via the `compilers.spack.yaml` file. Since this is abstract, there is a possibility that the spec doesn't align with later/different versions of the upstream. Hashes (via a lockfile) are unique and persistent. 

## The PR

* Use the `compilers.spack.lock` file stored in the upstream volume to unambigiously refer to the compiler packages
* Also bootstrap spack as part of the runner image, so we don't take 1 minute to bootstrap every time we spawn a runner

## Testing

Done in https://github.com/ACCESS-NRI/MOM6/actions/runs/17629880394/job/50095056910