### PR TITLE
Support multiple upstream volumes with different spack versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
         # FIXME: To be able to support both v0.22 and v1.0 upstreams at the same time
         # We need to pick the correct upstream volume based on the runner image spack version
         # This may not be required in the future if we only support v1.0+
-        - /opt/upstream${{ contains('v1.0', inputs.container-image-version) && '-v1.0' || '' }}:/opt/upstream${{ contains('v1.0', inputs.container-image-version) && '-v1.0' || '' }}:ro
+        - /opt/upstream${{ contains(inputs.container-image-version, 'v1.0') && '-v1.0' || '' }}:/opt/upstream${{ contains(inputs.container-image-version, 'v1.0') && '-v1.0' || '' }}:ro
         - /opt/runner_set_buildcache:/opt/runner_set_buildcache:rw
     outputs:
       spec-concretization-graph: ${{ steps.install.outputs.spec }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,6 @@ jobs:
     runs-on:
       group: build-ci
     container:
-      # image: ghcr.io/access-nri/build-ci-runner:${{ inputs.container-image-distro }}-${{ inputs.spack-version }}-${{ container-image-version }}
       image: ghcr.io/access-nri/build-ci-runner${{ inputs.container-image-version }}
       volumes:
         # FIXME: To be able to support both v0.22 and v1.0 upstreams at the same time

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,9 +173,8 @@ jobs:
       image: ghcr.io/access-nri/build-ci-runner${{ inputs.container-image-version }}
       volumes:
         # FIXME: To be able to support both v0.22 and v1.0 upstreams at the same time
-        # We would enable each upstream in the spack-config, depending on the spack version
+        # We need to pick the correct upstream volume based on the runner image spack version
         # This may not be required in the future if we only support v1.0+
-        # TODO: Update image tags to include vX spack versionL eg. :rocky-v0.22-2025.09.003
         - /opt/upstream${{ contains('v1.0', inputs.container-image-version) && '-v1.0' || '' }}:/opt/upstream${{ contains('v1.0', inputs.container-image-version) && '-v1.0' || '' }}:ro
         - /opt/runner_set_buildcache:/opt/runner_set_buildcache:rw
     outputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,16 +271,21 @@ jobs:
         run: |
           . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
 
+          # Get currently enabled upstream
+          upstream_path=$(spack config get upstreams | yq '.upstreams.upstream.install_tree')
+
           # Attempt a load of compilers via upstream compilers lockfile (if it exists)
-          if [ -f /opt/upstream/compilers.spack.lock ]; then
-            echo "Found /opt/upstream/compilers.spack.lock, attempting to load compilers from upstream"
-            yq '.roots[].hash' /opt/upstream/compilers.spack.lock | while read hash; do
+          if [ "$upstream_path" == "null" ]; then
+            echo "::notice::No upstream volume configured, skipping compiler load from upstream"
+          elif [ ! -f "$upstream_path/compilers.spack.lock" ]; then
+            echo "::warning::No $upstream_path/compilers.spack.lock found, skipping compiler load from upstream"
+          else
+            echo "Found $upstream_path/compilers.spack.lock, attempting to load compilers from upstream"
+            yq '.roots[].hash' "$upstream_path/compilers.spack.lock" | while read hash; do
               echo "Loading compiler with hash: $hash"
               spack load /$hash
               spack compiler find --scope=user
             done
-          else
-            echo "No /opt/upstream/compilers.spack.lock found, skipping compiler load from upstream"
           fi
 
           spack find

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,7 +272,7 @@ jobs:
           . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
 
           # Get currently enabled upstream
-          upstream_path=$(spack config get upstreams | yq '.upstreams.upstream.install_tree')
+          upstream_path="/opt/upstream${{ contains(inputs.container-image-version, 'v1.0') && '-v1.0' || '' }}"
 
           # Attempt a load of compilers via upstream compilers lockfile (if it exists)
           if [ "$upstream_path" == "null" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
         # We would enable each upstream in the spack-config, depending on the spack version
         # This may not be required in the future if we only support v1.0+
         - /opt/upstream:/opt/upstream:ro
-        - /opt/upstream-1.0:/opt/upstream-1.0:ro
+        - /opt/upstream-v1.0:/opt/upstream-v1.0:ro
         - /opt/runner_set_buildcache:/opt/runner_set_buildcache:rw
     outputs:
       spec-concretization-graph: ${{ steps.install.outputs.spec }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,11 @@ jobs:
     container:
       image: ghcr.io/access-nri/build-ci-runner${{ inputs.container-image-version }}
       volumes:
+        # FIXME: To be able to support both v0.22 and v1.0 upstreams at the same time
+        # We would enable each upstream in the spack-config, depending on the spack version
+        # This may not be required in the future if we only support v1.0+
         - /opt/upstream:/opt/upstream:ro
+        - /opt/upstream-1.0:/opt/upstream-1.0:ro
         - /opt/runner_set_buildcache:/opt/runner_set_buildcache:rw
     outputs:
       spec-concretization-graph: ${{ steps.install.outputs.spec }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
         # FIXME: To be able to support both v0.22 and v1.0 upstreams at the same time
         # We need to pick the correct upstream volume based on the runner image spack version
         # This may not be required in the future if we only support v1.0+
-        - /opt/upstream${{ contains(inputs.container-image-version, 'v1.0') && '-v1.0' || '' }}:/opt/upstream${{ contains(inputs.container-image-version, 'v1.0') && '-v1.0' || '' }}:ro
+        - /opt/upstream${{ contains(inputs.container-image-version, 'v1.0') && '-v1.0' || '' }}:/opt/upstream:ro
         - /opt/runner_set_buildcache:/opt/runner_set_buildcache:rw
     outputs:
       spec-concretization-graph: ${{ steps.install.outputs.spec }}
@@ -271,8 +271,7 @@ jobs:
         run: |
           . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
 
-          # Get currently enabled upstream
-          upstream_path="/opt/upstream${{ contains(inputs.container-image-version, 'v1.0') && '-v1.0' || '' }}"
+          upstream_path="/opt/upstream"
 
           # Attempt a load of compilers via upstream compilers lockfile (if it exists)
           if [ "$upstream_path" == "null" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,13 +169,14 @@ jobs:
     runs-on:
       group: build-ci
     container:
+      # image: ghcr.io/access-nri/build-ci-runner:${{ inputs.container-image-distro }}-${{ inputs.spack-version }}-${{ container-image-version }}
       image: ghcr.io/access-nri/build-ci-runner${{ inputs.container-image-version }}
       volumes:
         # FIXME: To be able to support both v0.22 and v1.0 upstreams at the same time
         # We would enable each upstream in the spack-config, depending on the spack version
         # This may not be required in the future if we only support v1.0+
-        - /opt/upstream:/opt/upstream:ro
-        - /opt/upstream-v1.0:/opt/upstream-v1.0:ro
+        # TODO: Update image tags to include vX spack versionL eg. :rocky-v0.22-2025.09.003
+        - /opt/upstream${{ contains('v1.0', inputs.container-image-version) && '-v1.0' || '' }}:/opt/upstream${{ contains('v1.0', inputs.container-image-version) && '-v1.0' || '' }}:ro
         - /opt/runner_set_buildcache:/opt/runner_set_buildcache:rw
     outputs:
       spec-concretization-graph: ${{ steps.install.outputs.spec }}


### PR DESCRIPTION
References #247

## Background

Currently, for `0.22` and `1.0` spack runners, we use a `0.22` upstream image for compatibility between the two. 

Unfortunately, the `1.0` runner doesn't understand what compilers are used in a `0.22` upstream, noting them as `no compiler`. This means that there is no upstream caching for `1.0` images. 

The solution that has been decided is to have two upstream volumes (`0.22` and `1.0`) in the cluster (see PR https://github.com/ACCESS-NRI/build-ci-k8s-infra/pull/3), and the determination for which to actually consider an upstream to be left to `spack-config` (see PR https://github.com/ACCESS-NRI/spack-config/pull/78).

## The PR

- **Add two read-only volumes for both 0.22 and 1.0 upstreams**
- **Load specific compilers.spack.yaml from chosen upstream**

## Testing

Done in https://github.com/ACCESS-NRI/MOM6/pull/30 (see run https://github.com/ACCESS-NRI/MOM6/actions/runs/17904675462/job/50903910096?pr=30#step:8:24, noting that the workflow failure is due to a perl bug that is fixed with a separate `spack-config-ref`)
