### PR TITLE
Dockerfile.base-spack: default to intel-oneapi-compilers-classic

### DIFF
--- a/config/compilers.json
+++ b/config/compilers.json
@@ -2,7 +2,7 @@
   {
     "COMPILER_NAME": "intel",
     "COMPILER_VERSION": "2021.10.0",
-    "COMPILER_PKG_NAME": "intel-oneapi-compilers",
-    "COMPILER_PKG_VERSION": "2023.2.4"
+    "COMPILER_PKG_NAME": "intel-oneapi-compilers-classic",
+    "COMPILER_PKG_VERSION": "2021.10.0"
   }
 ]

--- a/containers/Dockerfile.base-spack
+++ b/containers/Dockerfile.base-spack
@@ -113,8 +113,10 @@ ARG SPACK_PACKAGES_REPO_VERSION=main
 ARG SPACK_CONFIG_REPO_VERSION=main
 ARG SPACK_TARGET=x86_64
 ARG SPACK_CONFIG_DIR=/opt/spack-config/${SPACK_VERSION}/ci
-ARG COMPILER_PKG_NAME=intel-oneapi-compilers
-ARG COMPILER_PKG_VERSION=2023.2.4
+# Choose intel-oneapi-compilers-classic for ifort
+# Choose intel-oneapi-compilers for ifx
+ARG COMPILER_PKG_NAME=intel-oneapi-compilers-classic
+ARG COMPILER_PKG_VERSION=2021.10.0
 ARG COMPILER_NAME=intel
 ARG COMPILER_VERSION=2021.10.0
 


### PR DESCRIPTION
### Test
#### Spack v0.22
```
docker build -f Dockerfile.base-spack -t spack-dev-rocky:v0.22.5-intel-test --target dev --no-cache --progress=plain .
```
```
[root@dda43d178123 opt]# spack find
-- linux-rocky8-x86_64 / gcc@8.5.0 ------------------------------
gcc-runtime@8.5.0  intel-oneapi-compilers@2023.2.4
glibc@2.28         intel-oneapi-compilers-classic@2021.10.0
gmake@4.4.1        patchelf@0.17.2
...
```
#### Spack v1.0
```
docker build -f Dockerfile.base-spack -t spack-dev-rocky:v1.0.2-intel-test --build-arg SPACK_VERSION="v1.0" --build-arg SPACK_PACKAGES_REPO_VERSION="api-v2" --target dev --no-cache --progress=plain .
```
```
[root@a7eeb2140c5e /]# spack -V
1.0.2 (734c5db2121b01c373eed6538e452f18887e9e44)
[root@a7eeb2140c5e opt]# spack find intel-oneapi-compilers intel-oneapi-compilers-classic
-- linux-rocky8-x86_64 / no compilers ---------------------------
intel-oneapi-compilers@2023.2.4  intel-oneapi-compilers-classic@2021.10.0

-- linux-rocky8-x86_64_v4 / no compilers ------------------------
intel-oneapi-compilers-classic@2021.10.0
==> 3 installed packages
```