### PR TITLE
GitHub-Hosted: Re-find own compilers

### DIFF
--- a/.github/workflows/ci-github-hosted.yml
+++ b/.github/workflows/ci-github-hosted.yml
@@ -263,17 +263,23 @@ jobs:
         run: |
           . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
 
-          # Attempt a load of compilers via upstream compilers lockfile (if it exists)
-          if [ -f /opt/upstream/compilers.spack.lock ]; then
-            echo "Found /opt/upstream/compilers.spack.lock, attempting to load compilers from upstream"
-            yq '.roots[].hash' /opt/upstream/compilers.spack.lock | while read hash; do
-              echo "Loading compiler with hash: $hash"
-              spack load /$hash
-              spack compiler find --scope=user
-            done
+          # Find potential upstream compiler lockfile path
+          if [ -f "/opt/upstream/compilers.spack.lock" ]; then
+            compiler_lockfile_path="/opt/upstream/compilers.spack.lock"
+          elif [ -f "/opt/environments/compilers/spack.lock" ]; then
+            compiler_lockfile_path="/opt/environments/compilers/spack.lock"
           else
-            echo "No /opt/upstream/compilers.spack.lock found, skipping compiler load from upstream"
+            echo "::warning::No upstream compilers.spack.lock or environments/compilers/spack.lock found, skipping compiler load from upstream"
+            exit 0
           fi
+
+          # Attempt a load of compilers via upstream compilers lockfile
+          echo "Found $compiler_lockfile_path, attempting to load compilers from upstream"
+          yq '.roots[].hash' "$compiler_lockfile_path" | while read hash; do
+            echo "Loading compiler with hash: $hash"
+            spack load /$hash
+            spack compiler find --scope=user
+          done
 
           spack find
 

--- a/.github/workflows/ci-github-hosted.yml
+++ b/.github/workflows/ci-github-hosted.yml
@@ -310,7 +310,7 @@ jobs:
           OCI_PASSWORD: ${{ secrets.spack-oci-buildcache-password || secrets.GITHUB_TOKEN }}
         run: |
           . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
-          spack env activate compilers --create --prompt --envfile ${{ inputs.spack-compiler-manifest-path }}
+          spack env activate local_compilers --create --prompt --envfile ${{ inputs.spack-compiler-manifest-path }}
           spack --debug install --fail-fast --deprecated
           spack env deactivate
           yq '.spack.specs[]' ${{ inputs.spack-compiler-manifest-path }} | while read compiler; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,7 +317,7 @@ jobs:
           OCI_PASSWORD: ${{ secrets.spack-oci-buildcache-password || secrets.GITHUB_TOKEN }}
         run: |
           . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
-          spack env activate compilers --create --prompt --envfile ${{ inputs.spack-compiler-manifest-path }}
+          spack env activate local_compilers --create --prompt --envfile ${{ inputs.spack-compiler-manifest-path }}
           spack --debug install --fail-fast --deprecated
           spack env deactivate
           yq '.spack.specs[]' ${{ inputs.spack-compiler-manifest-path }} | while read compiler; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,21 +270,23 @@ jobs:
         run: |
           . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
 
-          upstream_path="/opt/upstream"
-
-          # Attempt a load of compilers via upstream compilers lockfile (if it exists)
-          if [ "$upstream_path" == "null" ]; then
-            echo "::notice::No upstream volume configured, skipping compiler load from upstream"
-          elif [ ! -f "$upstream_path/compilers.spack.lock" ]; then
-            echo "::warning::No $upstream_path/compilers.spack.lock found, skipping compiler load from upstream"
+          # Find potential upstream compiler lockfile path
+          if [ -f "/opt/upstream/compilers.spack.lock" ]; then
+            compiler_lockfile_path="/opt/upstream/compilers.spack.lock"
+          elif [ -f "/opt/environments/compilers/spack.lock" ]; then
+            compiler_lockfile_path="/opt/environments/compilers/spack.lock"
           else
-            echo "Found $upstream_path/compilers.spack.lock, attempting to load compilers from upstream"
-            yq '.roots[].hash' "$upstream_path/compilers.spack.lock" | while read hash; do
-              echo "Loading compiler with hash: $hash"
-              spack load /$hash
-              spack compiler find --scope=user
-            done
+            echo "::warning::No upstream compilers.spack.lock or environments/compilers/spack.lock found, skipping compiler load from upstream"
+            exit 0
           fi
+
+          # Attempt a load of compilers via upstream compilers lockfile
+          echo "Found $compiler_lockfile_path, attempting to load compilers from upstream"
+          yq '.roots[].hash' "$compiler_lockfile_path" | while read hash; do
+            echo "Loading compiler with hash: $hash"
+            spack load /$hash
+            spack compiler find --scope=user
+          done
 
           spack find
 


### PR DESCRIPTION
Closes #251

## Background

For some reason, updating to later versions of spack made it forget that the compilers were external. This step attempts to refind them from either `/opt/upstream/compilers.spack.lock` (for runners, implemented previously) or `/opt/environments/compilers/spack.lock` (for upstream, this PR). 

## The PR

- **Find compiler lockfile either from the upstream volume (if it exists) or the compilers environment**
- **Change local compiler environment name so it doesn't clash**

## Testing

Testing done in https://github.com/CABLE-LSM/CABLE/pull/618, specifically https://github.com/CABLE-LSM/CABLE/actions/runs/18214875186?pr=618
