### PR TITLE
`v2` Backport: Build-time buildcaches for images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,1 @@
-keys
-__pycache__
-.pytest_cache
-.vscode
+containers/upstream/secrets

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -207,7 +207,18 @@ LABEL org.opencontainers.image.source=https://github.com/ACCESS-NRI/build-ci
 
 # Install compilers and low-level, common packages
 COPY ${SOURCE_COMPILERS_SPACK_MANIFEST} ${ENV_COMPILERS_SPACK_MANIFEST}
-RUN <<EOF
+RUN --mount=type=secret,id=oci-username,env=OCI_USERNAME \
+    --mount=type=secret,id=oci-password,env=OCI_PASSWORD \
+    --mount=type=secret,id=oci-url,env=OCI_URL \
+    <<EOF
+spack mirror add \
+  --scope=system \
+  --autopush \
+  --unsigned \
+  --oci-username-variable OCI_USERNAME \
+  --oci-password-variable OCI_PASSWORD \
+  docker_build_buildcache $OCI_URL
+
 echo "Installing compilers"
 spack env activate compilers --create --envfile ${ENV_COMPILERS_SPACK_MANIFEST}
 spack spec
@@ -220,16 +231,32 @@ yq '.spack.specs[]' "${ENV_COMPILERS_SPACK_MANIFEST}" | while read compiler; do
 done
 
 spack clean --downloads --stage
+
+spack mirror remove --scope=system docker_build_buildcache
 EOF
 
 COPY ${SOURCE_PACKAGES_SPACK_MANIFEST} ${ENV_PACKAGES_SPACK_MANIFEST}
-RUN <<EOF
+RUN --mount=type=secret,id=oci-username,env=OCI_USERNAME \
+    --mount=type=secret,id=oci-password,env=OCI_PASSWORD \
+    --mount=type=secret,id=oci-url,env=OCI_URL \
+    <<EOF
+
+spack mirror add \
+  --scope=system \
+  --autopush \
+  --unsigned \
+  --oci-username-variable OCI_USERNAME \
+  --oci-password-variable OCI_PASSWORD \
+  docker_build_buildcache $OCI_URL
+
 echo "Installing common packages"
 spack env activate packages --create --envfile ${ENV_PACKAGES_SPACK_MANIFEST}
 spack install --deprecated --fail-fast || exit
 spack env deactivate
 
 spack clean --downloads --stage
+
+spack mirror remove --scope=system docker_build_buildcache
 EOF
 
 ################################################################################

--- a/containers/compose.dev.yaml
+++ b/containers/compose.dev.yaml
@@ -5,10 +5,8 @@ name: Spack Instance
 x-common-args: &common-args
   OS: rocky
   SPACK_VERSION: v0.22
-  SPACK_CONFIG_REPO_VERSION: 2025.03.0
   SOURCE_COMPILERS_SPACK_MANIFEST: upstream/dev/compilers.spack.yaml
   SOURCE_PACKAGES_SPACK_MANIFEST: upstream/dev/packages.spack.yaml
-
 services:
   upstream:
     container_name: Upstream
@@ -20,6 +18,10 @@ services:
       args:
         <<: *common-args
         SPACK_CONFIG_DIR: /opt/spack-config/v0.22/ci-upstream
+      secrets:
+        - oci-username
+        - oci-password
+        - oci-url
     volumes:
       - dev-upstream:/opt/upstream:rw
       - dev-buildcache:/opt/runner_set_buildcache:rw
@@ -43,3 +45,11 @@ services:
 volumes:
   dev-upstream:
   dev-buildcache:
+
+secrets:
+  oci-username:
+    file: upstream/secrets/oci-username.txt
+  oci-password:
+    file: upstream/secrets/oci-password.txt
+  oci-url:
+    file: upstream/secrets/oci-url.txt

--- a/containers/compose.prod.yaml
+++ b/containers/compose.prod.yaml
@@ -18,6 +18,10 @@ services:
       args:
         <<: *common-args
         SPACK_CONFIG_DIR: /opt/spack-config/v0.22/ci-upstream
+      secrets:
+        - oci-username
+        - oci-password
+        - oci-url
     volumes:
       - upstream:/opt/upstream:rw
       - buildcache:/opt/runner_set_buildcache:rw
@@ -41,3 +45,11 @@ services:
 volumes:
   upstream:
   buildcache:
+
+secrets:
+  oci-username:
+    file: upstream/secrets/oci-username.txt
+  oci-password:
+    file: upstream/secrets/oci-password.txt
+  oci-url:
+    file: upstream/secrets/oci-url.txt

--- a/containers/upstream/dev/compilers.spack.yaml
+++ b/containers/upstream/dev/compilers.spack.yaml
@@ -5,7 +5,7 @@ spack:
   # when running spack-enable.bash
   specs:
   - gcc@13.2.0 %gcc@8.5.0 target=x86_64
-  - intel-oneapi-compilers@2023.2.4 target=x86_64
+  - intel-oneapi-compilers-classic@2021.10.0 target=x86_64
   - intel-oneapi-compilers@2025.2.0 target=x86_64
   view: false
   concretizer:

--- a/containers/upstream/prod/compilers.spack.yaml
+++ b/containers/upstream/prod/compilers.spack.yaml
@@ -5,7 +5,7 @@ spack:
   # when running spack-enable.bash
   specs:
   - gcc@13.2.0 %gcc@8.5.0 target=x86_64
-  - intel-oneapi-compilers@2023.2.4 target=x86_64
+  - intel-oneapi-compilers-classic@2021.10.0 target=x86_64
   - intel-oneapi-compilers@2025.2.0 target=x86_64
   view: false
   concretizer:


### PR DESCRIPTION
Closes #254 

## Background

`v3` has a build-time buildcache for creation of it's images. Why does `v3` get all the fun and we get nothing!

In this PR, we backport the build-time buildcache functionality for `0.22` images as part of `v2`. This cuts down image build time from around 3 hours to less than an hour when the buildcache is hit most of the time. 

> [!NOTE]
> To use the buildcache as part of `docker compose build`, you will need to have a GitHub user, GitHub PAT with `packages:write`, and a OCI URL to a GitHub package as files in `containers/upstream/secrets/oci-[username|password|url].txt` respectively. 

## The PR

* Add a build-time OCI-backed buildcache for image generation, populated from secrets within `containers/upstream/secrets`