### PR TITLE
Output `spack config blame`, Continue on error for Log Creation

### DIFF
--- a/.github/workflows/ci-github-hosted.yml
+++ b/.github/workflows/ci-github-hosted.yml
@@ -362,6 +362,9 @@ jobs:
           echo "$(spack spec)" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+          # Output config before install for debugging
+          spack config blame
+
           spack --debug install --fail-fast --deprecated
 
       - name: Manifest - Push to Buildcache
@@ -388,6 +391,9 @@ jobs:
       - name: Manifest - Logs Create
         if: always() && (steps.install.conclusion == 'failure' || steps.install.conclusion == 'success')
         id: logs-create
+        # Logs may not be available if the spack install failed before concretization, so we'd rather direct users to the
+        # above install failure than have this step fail.
+        continue-on-error: true
         run: |
           . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
 

--- a/.github/workflows/ci-github-hosted.yml
+++ b/.github/workflows/ci-github-hosted.yml
@@ -363,7 +363,9 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
           # Output config before install for debugging
+          echo "::group::Spack Config Blame Output"
           spack config blame
+          echo "::endgroup::"
 
           spack --debug install --fail-fast --deprecated
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,7 +371,9 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
           # Output config before install for debugging
+          echo "::group::Spack Config Blame Output"
           spack config blame
+          echo "::endgroup::"
 
           spack --debug install --fail-fast --deprecated
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,6 +370,9 @@ jobs:
           echo "$(spack spec)" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+          # Output config before install for debugging
+          spack config blame
+
           spack --debug install --fail-fast --deprecated
 
       - name: Manifest - Push to Buildcache
@@ -395,6 +398,9 @@ jobs:
       - name: Manifest - Logs Create
         if: always() && (steps.install.conclusion == 'failure' || steps.install.conclusion == 'success')
         id: logs-create
+        # Logs may not be available if the spack install failed before concretization, so we'd rather direct users to the
+        # above install failure than have this step fail.
+        continue-on-error: true
         run: |
           . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
 


### PR DESCRIPTION
Closes #256

## Background

Currently the configuration used in an install is quite a black box, only inspectable if one has `inputs.allow-ssh-into-spack-install`

## The PR

* Output `spack config blame` in a `Spack Config Blame Output` group
* Also don't error out if logs can't be created, as this may be due to an earlier install failure, which we should point users towards instead. 
