### PR TITLE
Dockerfile.base-spack: make some commands conditional on Spack version

### DIFF
--- a/containers/Dockerfile.base-spack
+++ b/containers/Dockerfile.base-spack
@@ -12,7 +12,7 @@ ARG OS=rocky
 ################################################################################
 # NOTE: Keep an eye on:
 #       ${SPACK_ROOT}/share/spack/templates/container/rockylinux_8.dockerfile
-FROM rockylinux/rockylinux:8.10 as base-os-rocky
+FROM rockylinux/rockylinux:8.10 AS base-os-rocky
 
 # csh currently required for some build scripts e.g. MOM5
 RUN dnf update -y \
@@ -59,7 +59,7 @@ RUN dnf update -y \
 
 
 ################################################################################
-FROM opensuse/leap:15.5 as base-os-suse
+FROM opensuse/leap:15.5 AS base-os-suse
 
 # csh currently required for some build scripts e.g. MOM5
 RUN zypper ref \
@@ -104,7 +104,7 @@ RUN zypper ref \
 
 
 ################################################################################
-FROM base-os-$OS as base-spack
+FROM base-os-$OS AS base-spack
 
 ARG SPACK_GIT_URL=https://github.com/ACCESS-NRI/spack.git
 ARG SPACK_VERSION=v0.22
@@ -183,7 +183,7 @@ EOF
 
 
 ################################################################################
-FROM base-spack as ci
+FROM base-spack AS ci
 
 # Set up ACCESS Spack buildcache
 RUN pip3 install --no-cache-dir boto3==1.23.10
@@ -206,7 +206,7 @@ RUN --mount=type=secret,id=access-nri.pub \
 
 
 ################################################################################
-FROM base-spack as dev
+FROM base-spack AS dev
 
 ARG MPI_NAME=openmpi
 ARG MPI_VERSION=4.1.5

--- a/containers/Dockerfile.base-spack
+++ b/containers/Dockerfile.base-spack
@@ -145,8 +145,15 @@ SHELL ["/bin/bash", "-c"]
 RUN <<EOF
 git clone -c feature.manyFiles=true ${SPACK_GIT_URL} ${SPACK_ROOT} --branch ${SPACK_REPO_VERSION}
 
-# Install ACCESS-NRI's spack-packages repo
-git clone  https://github.com/ACCESS-NRI/spack-packages.git /opt/spack-packages --branch ${SPACK_PACKAGES_REPO_VERSION}
+# Install ACCESS-NRI's access-spack-packages repo for versions older than v1.0
+case "$SPACK_VERSION" in
+	v0*) git clone https://github.com/ACCESS-NRI/access-spack-packages.git /opt/spack-packages --branch ${SPACK_PACKAGES_REPO_VERSION}
+             ;;
+        v1*) echo "Spack v1.x manages access-spack-packages directly"
+             ;;
+        *) echo "Unknown Spack version"
+           ;;
+esac
 
 # Install ACCESS-NRI's spack-config repo
 git clone  https://github.com/ACCESS-NRI/spack-config.git /opt/spack-config --branch ${SPACK_CONFIG_REPO_VERSION}
@@ -212,8 +219,15 @@ ARG MPI_NAME=openmpi
 ARG MPI_VERSION=4.1.5
 
 RUN <<EOF
-spack load ${COMPILER_PKG_NAME}@${COMPILER_PKG_VERSION} \
- && spack compiler find
+case "$SPACK_VERSION" in
+	v0*) spack load ${COMPILER_PKG_NAME}@${COMPILER_PKG_VERSION}
+             spack compiler find
+             ;;
+        v1*) echo "Spack v1.x detects compilers directly"
+             ;;
+        *) echo "Unknown Spack version"
+           ;;
+esac
 
 spack install \
     gmake target=${SPACK_TARGET} %${COMPILER_NAME}@${COMPILER_VERSION}


### PR DESCRIPTION
This should hopefully be the final Dockerfile update for the `v1` branch. Then we move to the `v3` branch.

### Testing
```
$ docker build -f Dockerfile.base-spack -t spack-rocky:v0.22.5-intel-20251125-2 --target dev --no-cache --progress=plain .
...
#6 [base-spack 1/3] RUN <<EOF (git clone -c feature.manyFiles=true https://github.com/ACCESS-NRI/spack.git /opt/spack --branch releases/v0.22...)
#6 0.189 Cloning into '/opt/spack'...
#6 20.64 Cloning into '/opt/spack-packages'...
#6 21.53 Cloning into '/opt/spack-config'...
...
#9 [dev 1/1] RUN <<EOF (case "v0.22" in...)
#9 1.788 ==> Added 2 new compilers to /root/.spack/linux/compilers.yaml
#9 1.788     oneapi@2023.2.4
#9 1.788     intel@2021.10.0
#9 1.788 ==> Compilers are defined in the following files:
#9 1.788     /root/.spack/linux/compilers.yaml
```

```
$ docker build -f Dockerfile.base-spack -t spack-rocky:v1.1.0-intel-20251125 --build-arg SPACK_VERSION="v1.1" --build-arg SPACK_PACKAGES_REPO_VERSION="api-v2" --target dev --no-cache --progress=plain .
...
#6 [base-spack 1/3] RUN <<EOF (git clone -c feature.manyFiles=true https://github.com/ACCESS-NRI/spack.git /opt/spack --branch releases/v1.1...)
#6 0.245 Cloning into '/opt/spack'...
#6 48.23 Spack v1.x manages access-spack-packages directly
#6 48.23 Cloning into '/opt/spack-config'...
...
#9 [dev 1/1] RUN <<EOF (case "v1.1" in...)
#9 0.680 Spack v1.x detects compilers directly
```