### PR TITLE
Image Building CI

### DIFF
--- a/.github/data/nectar/openstack/requirements.txt
+++ b/.github/data/nectar/openstack/requirements.txt
@@ -1,0 +1,1 @@
+python-openstackclient==8.2.0

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -257,3 +257,23 @@ jobs:
           jq '.spec_concretization_graph' $f
         done
 ```
+
+## `containers-ci.yml` - Build and Push `build-ci-[upstream|runner]` Images
+
+### Overview
+
+This workflow handles building and pushing of images used in `ci.yml` on push to `v*`, or via `workflow_dispatch`.
+
+It stands up and tears down an ephemeral, powerful Nectar VM that builds the image via docker.
+
+### Inputs (via `workflow_dispatch`)
+
+| Name | Type | Description | Required | Default | Example |
+| ---- | ---- | ----------- | -------- | ------- | ------- |
+| `ref` | `string` (git ref) | Git ref for the build-ci repo to pull docker build files and config | `true` | N/A | tag: `rocky-v1.1-2025.12.000`, branch: `v3.1.0`, or commit `77f248c5a5f4af32bc1b1f5baebf08caf34db2d5` |
+| `pr-for-comment` | `string` (PR Number) | Comment the build result to this PR number | `false` | N/A | `12` |
+| `push` | `boolean` | Whether to push the given image once built. Will overwrite image if tags are the same | `true` | `false` | `true` or `false` |
+
+### Outputs
+
+None in GitHub Actions, but the image created by `containers/compose.prod.yaml` is pushed to `ghcr.io`.

--- a/.github/workflows/containers-ci.yml
+++ b/.github/workflows/containers-ci.yml
@@ -163,4 +163,4 @@ jobs:
         run: |
           gh pr comment ${{ inputs.pr-for-comment }} \
             --repo ${{ github.repository }} \
-            --body "Image at ${{ inputs.ref }} had build status `${{ steps.build.outcome }}` and push status `${{ steps.push.outcome }}`. See details at ${{ env.RUN_URL }}"
+            --body "Image at ${{ inputs.ref }} had build status `${{ steps.build.outcome }}` and push status `${{ steps.push.outcome }}`. If successful, image can be found in https://github.com/orgs/ACCESS-NRI/packages?tab=packages&q=build-ci-. See details at ${{ env.RUN_URL }}"

--- a/.github/workflows/containers-ci.yml
+++ b/.github/workflows/containers-ci.yml
@@ -1,4 +1,6 @@
 name: Image CI
+# NOTE: Information on secrets.[NECTAR_INSTANCE_SSH_KEY|NECTAR_INSTANCE_USER|GHCR_IMAGE_PUSH_TOKEN]
+# can be found in 'build-ci Image CI Secrets' in the secrets manager.
 on:
   push:
     branches:

--- a/.github/workflows/containers-ci.yml
+++ b/.github/workflows/containers-ci.yml
@@ -1,0 +1,147 @@
+name: Image CI
+on:
+  push:
+    branches:
+      - v*
+    paths:
+      - containers/upstream/prod
+      - containers/compose.prod.yaml
+      - containers/Dockerfile
+  workflow_dispatch:
+    inputs:
+      ref:
+        type: string
+        required: true
+        description: |
+          Git ref for the build-ci repo to pull docker build files and config
+      pr-for-comment:
+        type: string
+        required: false
+        description: |
+          Comment the build result to this PR number
+      push:
+        type: boolean
+        required: true
+        default: false
+        description: |
+          Whether to push the given image once built. Will overwrite image if tags are the same.
+env:
+  NECTAR_INSTANCE_NAME: runner-buildbox-${{ github.run_id }}
+jobs:
+  build-image-via-nectar:
+    name: Build
+    runs-on: ubuntu-latest
+    environment: Nectar Build
+    env:
+      # secrets needed for OpenStack authentication
+      OS_REGION_NAME: ${{ secrets.OS_REGION_NAME }}
+      OS_PROJECT_DOMAIN_ID: ${{ secrets.OS_PROJECT_DOMAIN_ID }}
+      OS_INTERFACE: ${{ secrets.OS_INTERFACE }}
+      OS_AUTH_URL: ${{ secrets.OS_AUTH_URL }}
+      OS_USERNAME: ${{ secrets.OS_USERNAME }}
+      OS_PROJECT_ID: ${{ secrets.OS_PROJECT_ID }}
+      OS_USER_DOMAIN_NAME: ${{ secrets.OS_USER_DOMAIN_NAME }}
+      OS_PROJECT_NAME: ${{ secrets.OS_PROJECT_NAME }}
+      OS_PASSWORD: ${{ secrets.OS_PASSWORD }}
+      OS_IDENTITY_API_VERSION: 3
+    steps:
+      - name: Checkout build-ci
+        uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+
+      - name: Install requirements for openstack
+        run: |
+          pip install -r .github/data/nectar/openstack/requirements.txt
+          openstack --version
+
+      - name: Setup SSH
+        id: ssh
+        uses: access-nri/actions/.github/actions/setup-ssh@main
+        with:
+          private-key: ${{ secrets.NECTAR_INSTANCE_SSH_KEY }}
+
+      - name: Create Instance
+        id: create
+        run: |
+          openstack server create ${{ env.NECTAR_INSTANCE_NAME }} \
+            --flavor p3.xxlarge \
+            --image "NeCTAR Ubuntu 22.04 LTS (Jammy) amd64 (with Docker)" \
+            --key-name runner-buildbox \
+            --availability-zone ardc-syd-1 \
+            --security-group ssh \
+            --nic net-id=${{ secrets.NECTAR_INSTANCE_NETWORK_ID }} \
+            --wait \
+            &> /dev/null
+
+          floating_ip=$(openstack floating ip create ardc-syd --format value --column floating_ip_address)
+          openstack server add floating ip ${{ env.NECTAR_INSTANCE_NAME }} $floating_ip
+
+          echo "floating-ip=$floating_ip" >> $GITHUB_OUTPUT
+
+          openstack server ssh --address-type=floating ${{ env.NECTAR_INSTANCE_NAME }} -- \
+            -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes \
+            -l ${{ secrets.NECTAR_INSTANCE_USER }} -i ${{ steps.ssh.outputs.private-key-path }} \
+            true
+
+      - name: Build Image
+        id: build
+        run: |
+          openstack server ssh --address-type=floating ${{ env.NECTAR_INSTANCE_NAME }} -- \
+            -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes -o ServerAliveInterval=5 \
+            -l ${{ secrets.NECTAR_INSTANCE_USER }} -i ${{ steps.ssh.outputs.private-key-path }} \
+            /bin/bash << EOT
+              # Secrets ingested by docker compose while building to make use of an OCI buildcache
+              export BUILD_CI_BUILDCACHE_OCI_USERNAME=${{ github.actor }}
+              export BUILD_CI_BUILDCACHE_OCI_PASSWORD=${{ github.token }}
+              export BUILD_CI_BUILDCACHE_OCI_URL=${{ secrets.BUILDCACHE_OCI_URL }}
+
+              git clone ${{ github.server_url }}/${{ github.repository }}
+              cd build-ci
+              git checkout ${{ inputs.ref || github.sha }}
+              sudo -E docker compose --progress=plain -f containers/compose.prod.yaml build
+          EOT
+
+      - name: Push Image
+        if: github.event_name == 'push' || inputs.push
+        id: push
+        run: |
+          openstack server ssh --address-type=floating ${{ env.NECTAR_INSTANCE_NAME }} -- \
+            -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes -o ServerAliveInterval=5 \
+            -l ${{ secrets.NECTAR_INSTANCE_USER }} -i ${{ steps.ssh.outputs.private-key-path }} \
+            /bin/bash << EOT
+              cd build-ci
+              echo ${{ secrets.GHCR_IMAGE_PUSH_TOKEN }} | sudo docker login ghcr.io -u ${{ github.actor }} --password-stdin
+              COMPOSE_BAKE=1 sudo docker compose --progress=plain -f containers/compose.prod.yaml push
+          EOT
+
+      - name: Teardown Instance
+        if: always()
+        run: |
+          if [ -n "${{ steps.create.outputs.floating-ip }}" ]; then
+            openstack floating ip delete ${{ steps.create.outputs.floating-ip }}
+            echo "Floating IP from this run deleted."
+          else
+            echo "No floating IP to delete from this run."
+          fi
+
+          if openstack server show ${{ env.NECTAR_INSTANCE_NAME }} &> /dev/null; then
+            openstack server delete ${{ env.NECTAR_INSTANCE_NAME }} --wait
+            echo "Nectar Instance from this run deleted."
+          else
+            echo "No Nectar Instance to delete from this run."
+          fi
+
+      - name: Comment on PR
+        if: always() && inputs.pr-for-comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh pr comment ${{ inputs.pr-for-comment }} \
+            --repo ${{ github.repository }} \
+            --body "Image at ${{ inputs.ref }} had build status `${{ steps.build.outcome }}` and push status `${{ steps.push.outcome }}`. See details at ${{ env.RUN_URL }}"

--- a/.github/workflows/containers-ci.yml
+++ b/.github/workflows/containers-ci.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - v*
     paths:
+      # These are the only files that affect image creation
       - containers/upstream/prod
       - containers/compose.prod.yaml
       - containers/Dockerfile
@@ -44,8 +45,14 @@ jobs:
       OS_PROJECT_NAME: ${{ secrets.OS_PROJECT_NAME }}
       OS_PASSWORD: ${{ secrets.OS_PASSWORD }}
       OS_IDENTITY_API_VERSION: 3
+    permissions:
+      # For commenting on a PR
+      pull-requests: write
+      # To write back buildcache entries
+      packages: write
     steps:
       - name: Checkout build-ci
+        # To get openstack requirements file
         uses: actions/checkout@v5
 
       - name: Setup Python
@@ -61,12 +68,15 @@ jobs:
 
       - name: Setup SSH
         id: ssh
+        # Get appropriate runner-buildbox key to SSH into Nectar Instance
         uses: access-nri/actions/.github/actions/setup-ssh@main
         with:
           private-key: ${{ secrets.NECTAR_INSTANCE_SSH_KEY }}
 
       - name: Create Instance
         id: create
+        # Create ephemeral, powerful Nectar Instance, create and assign a floating IP as part of
+        # the private runner-buildbox network so GitHub Actions can SSH into it.
         run: |
           openstack server create ${{ env.NECTAR_INSTANCE_NAME }} \
             --flavor p3.xxlarge \
@@ -83,6 +93,7 @@ jobs:
 
           echo "floating-ip=$floating_ip" >> $GITHUB_OUTPUT
 
+          # We test out SSHing into the server here, as sometimes we get Connection Refused the first attempt.
           openstack server ssh --address-type=floating ${{ env.NECTAR_INSTANCE_NAME }} -- \
             -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes \
             -l ${{ secrets.NECTAR_INSTANCE_USER }} -i ${{ steps.ssh.outputs.private-key-path }} \
@@ -90,6 +101,8 @@ jobs:
 
       - name: Build Image
         id: build
+        # Build the build-ci-[upstream|runner] image using the instance
+        # Setup environment-variable secrets for the OCI-backed spack buildcache to make installs faster
         run: |
           openstack server ssh --address-type=floating ${{ env.NECTAR_INSTANCE_NAME }} -- \
             -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes -o ServerAliveInterval=5 \
@@ -109,6 +122,7 @@ jobs:
       - name: Push Image
         if: github.event_name == 'push' || inputs.push
         id: push
+        # Push the just built image to GHCR
         run: |
           openstack server ssh --address-type=floating ${{ env.NECTAR_INSTANCE_NAME }} -- \
             -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes -o ServerAliveInterval=5 \
@@ -121,6 +135,8 @@ jobs:
 
       - name: Teardown Instance
         if: always()
+        # Disassociate and release the floating IP, and then delete the ephemeral Nectar Instance.
+        # If this somehow doesn't run, the p3 flavor cleans itself up after 24 hours automatically (see Nectar docs)
         run: |
           if [ -n "${{ steps.create.outputs.floating-ip }}" ]; then
             openstack floating ip delete ${{ steps.create.outputs.floating-ip }}
@@ -138,6 +154,7 @@ jobs:
 
       - name: Comment on PR
         if: always() && inputs.pr-for-comment
+        # A QoL thing - maybe for testing we want to link back to a PR with the results of the build?
         env:
           GH_TOKEN: ${{ github.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ These are repositories that use the `build-ci-enabled` tag, which can be given b
 
 This repository contains reusable workflows used as common entrypoints into a model component build and test pipeline. See the [Entrypoint Workflows section](#using-the-entrypoint-workflows) for more information.
 
-This repository also contains the resources required to build images that are used by the CI infrastructure in `ACCESS-NRI/build-ci-k8s-infra` (which is private), as well as local builds via `docker compose`. More information on this section can be found in it's own [dedicated README.md](./containers/README.md).
+This repository also contains the resources required to build images that are used by the CI infrastructure in `ACCESS-NRI/build-ci-k8s-infra` (which is private), as well as local builds via `docker compose`. It also contains a pipeline for automatic builds of said images on push to `v*`. More information on this section can be found in it's own [dedicated README.md](./containers/README.md).
 
 ## Usage
 

--- a/containers/README.md
+++ b/containers/README.md
@@ -8,6 +8,8 @@ This folder contains the `Dockerfile` and `compose.*.yaml` files needed to build
 
 Furthermore, those images download upstream compilers and common packages informed by the `upstream/[dev|prod]/[packages|compilers].spack.yaml` spack manifests.
 
+This folder is used to inform the `.github/workflows/containers-ci.yml` file, which builds the images automatically. More info can be found [in the workflows README.md](./../.github/workflows/README.md).
+
 ## How to build `spack` for testing
 
 You can use spack in a similar way to `build-ci`, with it's own upstream `spack` used for compilers and common packages. This is also suitable for developers to test. Run the following Docker Compose commands:

--- a/containers/compose.dev.yaml
+++ b/containers/compose.dev.yaml
@@ -47,8 +47,8 @@ volumes:
 
 secrets:
   oci-username:
-    file: upstream/secrets/oci-username.txt
+    environment: BUILD_CI_BUILDCACHE_OCI_USERNAME
   oci-password:
-    file: upstream/secrets/oci-password.txt
+    environment: BUILD_CI_BUILDCACHE_OCI_PASSWORD
   oci-url:
-    file: upstream/secrets/oci-url.txt
+    environment: BUILD_CI_BUILDCACHE_OCI_URL

--- a/containers/compose.prod.yaml
+++ b/containers/compose.prod.yaml
@@ -47,8 +47,8 @@ volumes:
 
 secrets:
   oci-username:
-    file: ./upstream/secrets/oci-username.txt
+    environment: BUILD_CI_BUILDCACHE_OCI_USERNAME
   oci-password:
-    file: ./upstream/secrets/oci-password.txt
+    environment: BUILD_CI_BUILDCACHE_OCI_PASSWORD
   oci-url:
-    file: ./upstream/secrets/oci-url.txt
+    environment: BUILD_CI_BUILDCACHE_OCI_URL


### PR DESCRIPTION
Closes #202

## Background

Laptops are melting trying to build these intensive images, we need to offload it somewhere. Even better if it was automated!

In this PR, we automatically build the `build-ci-runner`/`build-ci-upstream` images on push, or via a workflow_dispatch event. We create short-lived but powerful VMs on Nectar via openstack, build and push on those VMs, and then tear them down.  

## The PR

- **Change compose secrets from file to environment variables, to support CI image builds**
- **Add containers-ci.yml to build CI images on push/workflow_dispatch using nectar VMs**
- **Update README.md**

## Testing

Successful run: https://github.com/ACCESS-NRI/build-ci/actions/runs/20474219186
And uploaded package: https://github.com/ACCESS-NRI/build-ci/pkgs/container/build-ci-runner/621627351?tag=rocky-v1.1-2025.12.000-test and https://github.com/ACCESS-NRI/build-ci/pkgs/container/build-ci-upstream/621627351?tag=rocky-v1.1-2025.12.000-test
