### PR TITLE
Get Manifest From Any Repository

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,8 +10,10 @@ This workflow handles building and running short CI tests on a given spack manif
 
 | Name | Type | Description | Required | Default | Example |
 | ---- | ---- | ----------- | -------- | ------- | ------- |
+| `spack-manifest-repository` | `string` (`OWNER/REPO` format) | The repository containing the spack manifest to install | `false` | `github.repository` (AKA, the caller repository) | For example: ACCESS-NRI/access-test-component |
+| `spack-manifest-repository-ref` | `string` (Git ref) | The branch, tag, or commit SHA of the `inputs.spack-manifest-repository` to use | `false` | For a `inputs.spack-manifest-repository` the same as the caller repository, it will attempt to use the callers SHA, otherwise it will default to the default branch of the `inputs.spack-manifest-repository` | `main`, `2025.03.0`, `r23ij2o3` |
 | `spack-manifest-path` | `string` (Path relative to component repository root) |  File path in the caller model component repository that contains the spack manifest jinja template to install | `true` | N/A | `".github/build/manifests/template/access-om2.spack.yaml.j2"`, `".github/some.spack.yaml"` |
-| `spack-manifest-data-path`| `string` (Path relative to component repository root) | File path in the caller model component repository that contains jinja data to fill in to the spack manifest jinja template given by `inputs.spack-manifest-path`. This doesn't include the pull request ref (`{{ pr }}`), which is filled in automatically | `false` | N/A | `".github/build/data/template-data.json"` |
+| `spack-manifest-data-path`| `string` (Path relative to component repository root) | File path in the caller model component repository that contains jinja data to fill in to the spack manifest jinja template given by `inputs.spack-manifest-path`. This doesn't include the pull request ref (`{{ ref }}`), which is filled in automatically | `false` | N/A | `".github/build/data/template-data.json"` |
 | `spack-compiler-manifest-path` | `string` (Path relative to component repository root) | A file path in the caller model component repository that contains the spack manifest to install local compilers not in the upstream | `false` | N/A | `".github/build/compilers/intel-2021.11.0.spack.yml"` |
 | `spack-manifest-data-pairs` | `string` | An optional, multi-line string of space-separated key-value pairs to fill in `inputs.spack-manifest-path`. This is useful for filling in template values created dynamically by earlier jobs needed by this workflow. This doesn't include `{{ ref }}`, which is filled in automatically. | `false` | N/A | `"package mom5`(newline)`compiler intel"` |
 | `ref` | `string` (Git ref) | The branch, tag, or commit SHA of the caller model component repository | `false` | `github.event.pull_request.head.sha` for PRs, `github.sha` otherwise | `"c0fef23fc1e69d3a31ec18fd8b7102acdf95f651"`, `"main"`, `"2025.01.000"` |
@@ -48,6 +50,7 @@ This workflow handles building and running short CI tests on a given spack manif
 | `spack-config-sha` | `string` (Git commit SHA) | The SHA of the `ACCESS-NRI/spack-config` repository checked out | `"c0fef23fc1e69d3a31ec18fd8b7102acdf95f651"` |
 | `builtin-spack-packages-sha` | `string` (Git commit SHA) | The SHA of the `spack/spack-packages` repository checked out | `"9225ee95da5c6e212a80d933db8aca44271417a3"` |
 | `access-spack-packages-sha` | `string` (Git commit SHA) | The SHA of the `ACCESS-NRI/access-spack-packages` repository checked out | `"2acb57187fc75c0fc83c898d1dd47bdaced2fca9"` |
+| `spack-manifest-repository-sha` | `string` (Git commit SHA) | The SHA of the spack manifest repository checked out | `24ef5da423028a9a25133884e6e402900e87a3aa` |
 | `sha` | `string` (Git commit SHA) | The SHA of the caller model component repository checked out | `"43ef5da423028a9a25133884e6e402900e87a3ce"` |
 | `container-id` | `string` | The ID of the container where the spack packages have been installed | `"ohfn2ofy2h2uyfg2uyg3uyg3uh"` |
 | `spack-files-artifact-pattern` | `string` (glob) | Wildcard pattern to match all spack file artifacts across a matrix job | `'spack-files-*'` |
@@ -82,6 +85,8 @@ jobs:
   test:
     uses: access-nri/build-ci/.github/workflows/ci.yml@v3
     with:
+      spack-manifest-repository: some-org/build-ci-manifests
+      spack-manifest-repository-ref: main
       spack-manifest-path: .github/build/spack.yaml.j2
       spack-manifest-data-path: .github/build/data/data.json
       spack-compiler-manifest-path: .github/build/compiler/intel.spack.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,17 +3,33 @@ run-name: CI Test ${{ github.repository }} at ${{ github.event.number }} (${{ gi
 on:
   workflow_call:
     inputs:
+      spack-manifest-repository:
+        required: false
+        type: string
+        default: ${{ github.repository }}
+        description: |
+          The repository containing the spack manifest to install.
+          By default, this is the caller model component repository, which will work for most use-cases.
+          For example: ACCESS-NRI/access-test-component.
+      spack-manifest-repository-ref:
+        required: false
+        type: string
+        # If the inputs.spack-manifest-repository is the same as the caller repo, use the same heuristic as inputs.ref (use the caller SHA), otherwise use the default ref
+        default: ${{ inputs.spack-manifest-repository == github.repository && (github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha) || '' }}
+        description: |
+          The branch, tag, or commit SHA of the inputs.spack-manifest-repository to use.
+          For example: main, 2025.03.0, r23ij2o3.
       spack-manifest-path:
         required: true
         type: string
         description: |
-          A file path in the caller model component repository that contains the spack manifest template to install.
+          A file path in the inputs.spack-manifest-repository that contains the spack manifest template to install.
           For example: .github/build/manifests/template/access-om2.spack.yaml.j2.
       spack-manifest-data-path:
         required: false
         type: string
         description: |
-          An optional file path in the caller model component repository that contains data to fill in the spack manifest jinja template.
+          An optional file path in the inputs.spack-manifest-repository that contains data to fill in the spack manifest jinja template.
           This doesn't include {{ ref }}, which is filled in automatically.
           For example: .github/build/manifests/data/access-om2.spack.yaml.j2.json.
       spack-manifest-data-pairs:
@@ -30,7 +46,7 @@ on:
         required: false
         type: string
         description: |
-          A file path in the caller model component repository that contains the spack manifest to install local compilers not in the upstream.
+          A file path in the inputs.spack-manifest-repository that contains the spack manifest to install local compilers not in the upstream.
           For example: .github/build/manifests/compilers.spack.yaml.
       ref:
         required: false
@@ -125,6 +141,10 @@ on:
         value: ${{jobs.spack-install-and-test.outputs.spec-concretization-graph }}
         description: |
           A visual representation of the dependencies and constraints of the spack manifest file installed.
+      spack-manifest-repository-sha:
+        value: ${{ jobs.spack-install-and-test.outputs.spack-manifest-repository-sha }}
+        description: |
+          The SHA of the spack manifest repository checked out.
       spack-sha:
         value: ${{ jobs.spack-install-and-test.outputs.spack-sha }}
         description: |
@@ -195,11 +215,12 @@ jobs:
         - ${{ inputs.run-self-hosted && '/opt/runner_set_buildcache:/opt/runner_set_buildcache:rw' || '/dev/null:/dev/null:ro' }}
     outputs:
       spec-concretization-graph: ${{ steps.install.outputs.spec }}
+      spack-manifest-repository-sha: ${{ steps.checkout.outputs.commit }}
       spack-sha: ${{ steps.spack-update.outputs.sha }}
       spack-config-sha: ${{ steps.spack-config-update.outputs.sha }}
       builtin-spack-packages-sha: ${{ steps.builtin-spack-packages-update.outputs.sha }}
       access-spack-packages-sha: ${{ steps.access-spack-packages-update.outputs.sha }}
-      sha: ${{ steps.checkout.outputs.commit }}
+      sha: ${{ steps.checkout-caller.outputs.commit }}
       spack-files-artifact-pattern: ${{ steps.env.outputs.spack-files-artifact-pattern }}
       spack-files-artifact-url: ${{ steps.manifest-upload.outputs.artifact-url }}
       job-output-artifact-pattern: ${{ steps.env.outputs.job-output-artifact-pattern }}
@@ -348,11 +369,20 @@ jobs:
             oci_buildcache ${{ inputs.spack-oci-buildcache-url }}
           spack mirror list
 
-      - name: Manifest - Checkout ${{ github.repository }}
-        id: checkout
+      - name: Manifest - Checkout Caller ${{ github.repository }}
+        id: checkout-caller
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
+          submodules: recursive
+          path: caller
+
+      - name: Manifest - Checkout Manifest From ${{ inputs.spack-manifest-repository }}
+        id: checkout
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.spack-manifest-repository }}
+          ref: ${{ inputs.spack-manifest-repository-ref }}
           submodules: recursive
 
       - name: Manifest - Install Compilers Locally
@@ -521,6 +551,8 @@ jobs:
              --arg pairs "$serialized_spack_manifest_data_pairs" \
           '{
             "spack_manifest_path": "${{ inputs.spack-manifest-path }}",
+            "spack_manifest_repository": "${{ inputs.spack-manifest-repository }}",
+            "spack_manifest_repository_ref": "${{ inputs.spack-manifest-repository-ref }}",
             "spack_manifest_data_path": "${{ inputs.spack-manifest-data-path }}",
             "spack_manifest_data_pairs": $pairs,
             "spack_compiler_manifest_path": "${{ inputs.spack-compiler-manifest-path }}",
@@ -536,11 +568,12 @@ jobs:
             "spack_install_result": "${{ steps.install.conclusion }}",
 
             "spec_concretization_graph": $spec,
+            "spack_manifest_repository_sha": "${{ steps.checkout.outputs.commit }}",
             "spack_sha": "${{ steps.spack-update.outputs.sha }}",
             "spack_config_sha": "${{ steps.spack-config-update.outputs.sha }}",
             "builtin_spack_packages_sha": "${{ steps.builtin-spack-packages-update.outputs.sha }}",
             "access_spack_packages_sha": "${{ steps.access-spack-packages-update.outputs.sha }}",
-            "sha": "${{ steps.checkout.outputs.commit }}",
+            "sha": "${{ steps.checkout-caller.outputs.commit }}",
             "container_id": "${{ steps.env.outputs.container-id }}",
             "short_container_id": "${{ steps.env.outputs.short-container-id }}",
             "spack_files_artifact_pattern": "${{ steps.env.outputs.spack-files-artifact-pattern }}",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,8 @@ on:
         required: false
         type: string
         # If the inputs.spack-manifest-repository is the same as the caller repo, use the same heuristic as inputs.ref (use the caller SHA), otherwise use the default ref
-        default: ${{ inputs.spack-manifest-repository == github.repository && (github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha) || '' }}
+        # Unfortunately, we can't set expressions as defaults yet, so this is set in the step that checks out the manifest repository
+        # default: ${{ inputs.spack-manifest-repository == github.repository && (github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha) || '' }}
         description: |
           The branch, tag, or commit SHA of the inputs.spack-manifest-repository to use.
           For example: main, 2025.03.0, r23ij2o3.
@@ -221,32 +222,41 @@ jobs:
       builtin-spack-packages-sha: ${{ steps.builtin-spack-packages-update.outputs.sha }}
       access-spack-packages-sha: ${{ steps.access-spack-packages-update.outputs.sha }}
       sha: ${{ steps.checkout-caller.outputs.commit }}
-      spack-files-artifact-pattern: ${{ steps.env.outputs.spack-files-artifact-pattern }}
+      spack-files-artifact-pattern: ${{ steps.init.outputs.spack-files-artifact-pattern }}
       spack-files-artifact-url: ${{ steps.manifest-upload.outputs.artifact-url }}
-      job-output-artifact-pattern: ${{ steps.env.outputs.job-output-artifact-pattern }}
+      job-output-artifact-pattern: ${{ steps.init.outputs.job-output-artifact-pattern }}
       job-output-artifact-url: ${{ steps.output-upload.outputs.artifact-url }}
-      spack-logs-artifact-pattern: ${{ steps.env.outputs.spack-logs-artifact-pattern }}
+      spack-logs-artifact-pattern: ${{ steps.init.outputs.spack-logs-artifact-pattern }}
       spack-logs-artifact-url: ${{ steps.logs-upload.outputs.artifact-url }}
-      container-id: ${{ steps.env.outputs.container-id }}
-      short-container-id: ${{ steps.env.outputs.short-container-id }}
+      container-id: ${{ steps.init.outputs.container-id }}
+      short-container-id: ${{ steps.init.outputs.short-container-id }}
       # test-artifact-url: ${{ steps.test.outputs.artifact-url }}
     steps:
-      - name: Init - Export environment variables into GitHub Actions format
-        # Environment variables inside containers are not accessible in the `env` context,
-        # a context which would be used in future conditional steps.
-        # This step exports important container environment variables as outputs.
-        # And yes, this loop echoes name-of-var=value-of-var!
-        id: env
+      - name: Init - Initalize dynamic vars
+        id: init
+        # GitHub Actions doesn't allow expressions in the on.workflow_call.inputs.*.default section, so we need to define them here
+        # Furthermore, some outputs depend on the container being started, so we define them here as well
         run: |
-          for var in SPACK_ROOT INITIAL_SPACK_REPO_VERSION; do
-            echo "$var=${!var}" >> $GITHUB_OUTPUT
-          done
+          # Initializing dynamic default of inputs.spack-manifest-repository-ref...
 
-          # The upload step later requires a non-relative path, hence the realpath
-          echo "spack-env-dir=$(realpath $SPACK_ROOT/../environments)" >> $GITHUB_OUTPUT
+          if [[ "${{ inputs.spack-manifest-repository-ref }}" != "" ]]; then
+            spack_manifest_repository_ref=${{ inputs.spack-manifest-repository-ref }}
+          elif [[ "${{ inputs.spack-manifest-repository }}" == "${{ github.repository }}" ]]; then
+            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+              spack_manifest_repository_ref=${{ github.event.pull_request.head.sha }}
+            else
+              spack_manifest_repository_ref=${{ github.sha }}
+            fi
+          fi
 
+          echo "spack-manifest-repository-ref: $spack_manifest_repository_ref"
+          echo "spack-manifest-repository-ref=$spack_manifest_repository_ref" >> $GITHUB_OUTPUT
+
+          # Initializing container id and associated artifact globs/filenames...
           container_id=${{ job.container.id }}
           short_container_id=${container_id:0:8}
+
+          echo "::notice::Short Container ID used for artifacts in this job: $short_container_id"
 
           # We can only get the job.container.id after the container is started, so we set it as the file name here
           echo "job-output-artifact-name=job-output-$short_container_id" >> $GITHUB_OUTPUT
@@ -260,6 +270,20 @@ jobs:
 
           echo "container-id=$container_id" >> $GITHUB_OUTPUT
           echo "short-container-id=$short_container_id" >> $GITHUB_OUTPUT
+
+      - name: Init - Export environment variables into GitHub Actions format
+        # Environment variables inside containers are not accessible in the `env` context,
+        # a context which would be used in future conditional steps.
+        # This step exports important container environment variables as outputs.
+        # And yes, this loop echoes name-of-var=value-of-var!
+        id: env
+        run: |
+          for var in SPACK_ROOT INITIAL_SPACK_REPO_VERSION; do
+            echo "$var=${!var}" >> $GITHUB_OUTPUT
+          done
+
+          # The upload step later requires a non-relative path, hence the realpath
+          echo "spack-env-dir=$(realpath $SPACK_ROOT/../environments)" >> $GITHUB_OUTPUT
 
       - name: Update - spack-config version
         id: spack-config-update
@@ -382,7 +406,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ inputs.spack-manifest-repository }}
-          ref: ${{ inputs.spack-manifest-repository-ref }}
+          ref: ${{ steps.init.outputs.spack-manifest-repository-ref }}
           submodules: recursive
 
       - name: Manifest - Install Compilers Locally
@@ -472,7 +496,7 @@ jobs:
         # Upload spack manifest and lock files
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.env.outputs.spack-files-artifact-name }}
+          name: ${{ steps.init.outputs.spack-files-artifact-name }}
           path: ${{ steps.env.outputs.spack-env-dir }}/default/spack.*
           if-no-files-found: error
 
@@ -508,7 +532,7 @@ jobs:
         id: logs-upload
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.env.outputs.spack-logs-artifact-name }}
+          name: ${{ steps.init.outputs.spack-logs-artifact-name }}
           path: logs/*.log
           if-no-files-found: warn
 
@@ -552,7 +576,7 @@ jobs:
           '{
             "spack_manifest_path": "${{ inputs.spack-manifest-path }}",
             "spack_manifest_repository": "${{ inputs.spack-manifest-repository }}",
-            "spack_manifest_repository_ref": "${{ inputs.spack-manifest-repository-ref }}",
+            "spack_manifest_repository_ref": "${{ steps.init.outputs.spack-manifest-repository-ref }}",
             "spack_manifest_data_path": "${{ inputs.spack-manifest-data-path }}",
             "spack_manifest_data_pairs": $pairs,
             "spack_compiler_manifest_path": "${{ inputs.spack-compiler-manifest-path }}",
@@ -575,20 +599,20 @@ jobs:
             "builtin_spack_packages_sha": "${{ steps.builtin-spack-packages-update.outputs.sha }}",
             "access_spack_packages_sha": "${{ steps.access-spack-packages-update.outputs.sha }}",
             "sha": "${{ steps.checkout-caller.outputs.commit }}",
-            "container_id": "${{ steps.env.outputs.container-id }}",
-            "short_container_id": "${{ steps.env.outputs.short-container-id }}",
-            "spack_files_artifact_pattern": "${{ steps.env.outputs.spack-files-artifact-pattern }}",
+            "container_id": "${{ steps.init.outputs.container-id }}",
+            "short_container_id": "${{ steps.init.outputs.short-container-id }}",
+            "spack_files_artifact_pattern": "${{ steps.init.outputs.spack-files-artifact-pattern }}",
             "spack_files_artifact_url": "${{ steps.manifest-upload.outputs.artifact-url }}",
-            "job_output_artifact_pattern": "${{ steps.env.outputs.job-output-artifact-pattern }}",
+            "job_output_artifact_pattern": "${{ steps.init.outputs.job-output-artifact-pattern }}",
             "spack_logs_artifact_url": "${{ steps.logs-upload.outputs.artifact-url }}",
-            "spack_logs_artifact_pattern": "${{ steps.env.outputs.artifact-pattern }}"
-          }' > ./${{ steps.env.outputs.job-output-artifact-name }}
+            "spack_logs_artifact_pattern": "${{ steps.init.outputs.spack-logs-artifact-pattern }}"
+          }' > ./${{ steps.init.outputs.job-output-artifact-name }}
 
       - name: Job Outputs - Upload
         if: always() && (steps.install.conclusion == 'failure' || steps.install.conclusion == 'success')
         id: output-upload
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.env.outputs.job-output-artifact-name }}
-          path: ./${{ steps.env.outputs.job-output-artifact-name }}
+          name: ${{ steps.init.outputs.job-output-artifact-name }}
+          path: ./${{ steps.init.outputs.job-output-artifact-name }}
           if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -564,6 +564,7 @@ jobs:
             "pytest_test_markers": "${{ inputs.pytest-test-markers }}",
             "allow_ssh_into_spack_install": "${{ inputs.allow-ssh-into-spack-install }}",
             "container_image_version": "${{ inputs.container-image-version }}",
+            "run_self_hosted": "${{ inputs.run-self-hosted }}",
 
             "spack_install_result": "${{ steps.install.conclusion }}",
 


### PR DESCRIPTION
Closes #264

> [!NOTE]
> Since the new inputs are optional and default to the existing functionality, this update is considered MINOR.

## Background

Currently, all spack manifests (test ones, compiler ones, and data) are invariably sourced from the caller repository. This is fine for the vast majority of cases (eg. MCRs), but for `access-spack-packages` and `spack-config`, we need to have manifests defined in their respective repositories, leading the manifests becoming somewhat out of sync. 

If we can instead source manifests from a given repository, rather than the caller, we can have manifests defined in a single repository as a single source of truth, whether that be an MCR, a `build-ci` manifest repository, `access-spack-packages`, or in the caller as we currently have it. This means that there can be less duplication of test manifests, or less of a need to re-unify manifests as things change. 

### For example...

#### Using the new inputs

```yaml
uses: access-nri/build-ci/.github/workflows/ci.yml@v3
with:
  spack-manifest-repository: access-nri/access-spack-packages  # Repo must be accessible publicly
  spack-manifest-repository-ref: api-v2  # Can be any ref
  spack-manifest-path: .github/build-ci/manifests/cice4/intel.spack.yaml.j2  # Relative to the inputs.spack-manifest-repository (AKA access-spack-packages)
  spack-manifest-data-path: .github/build-ci/data/standard_definitions.json  # Also relative to the inputs.spack-manifest-repository (AKA access-spack-packages)
```

#### Not using the new inputs

```yaml
uses: access-nri/build-ci/.github/workflows/ci.yml@v3
with:
  # spack-manifest-repository: github.repository  # AKA, the caller repository
  # spack-manifest-repository-ref: github.sha if the caller repository, default branch otherwise
  spack-manifest-path: .github/build-ci/manifests/spack.yaml.j2  # Relative to the caller repository
  spack-manifest-data-path: .github/build-ci/data/standard_definitions.json  # Also relative to the caller repository
```


## This PR

- **Add new optional `inputs.[spack-manifest-repository|spack-manifest-repository-ref]` Defaults to github.repository and an appropriate github.sha respectively. Also added new outputs.spack-manifest-repository-sha.**
- **Split `steps.env` step into `steps.init` (for dynamic default resolution/setting initial vars) and `steps.env` (for exporting container vars)**
- **Output inputs.run-self-hosted in output artifact** - forgot to add this in a previous PR!

## Testing

### Default Case: `inputs.spack-manifest-repository[-ref]` Both Left Blank

Succeded: https://github.com/ACCESS-NRI/access-test-component/actions/runs/20769455432?pr=16

The [`steps.init.outputs.spack-manifest-repository-ref`](https://github.com/ACCESS-NRI/access-test-component/actions/runs/20769455432/job/59642331383?pr=16#step:3:35) was generated to be the same as the [`inputs.ref`](https://github.com/ACCESS-NRI/access-test-component/actions/runs/20769455432/job/59642331383?pr=16#step:1:32) given the `inputs.spack-manifest-repository` was the same as the caller repository - `fb0cdc5aad03c13874a25cb568a8b0d4cbb50c0c`.

### `inputs.spack-manifest-repository` Set, `inputs.spack-manifest-repository-ref` Left Blank

Succeeded: https://github.com/ACCESS-NRI/access-test-component/actions/runs/20769694040/job/59643047390?pr=16

The set `inputs.spack-manifest-repository` correctly cloned the `codegat-test-org/test` at the default branch since `inputs.spack-manifest-repository-ref` was left blank. Set to `750ac2c5d1dcb6188654c1badbaac46bdc4f41fa` (the current `main`)

### `inputs.spack-manifest-repository[-ref]` Both Set

Succeeded: https://github.com/ACCESS-NRI/access-test-component/actions/runs/20769810014/job/59643402114?pr=16

The set `inputs.spack-manifest-repository` correctly cloned the `codegat-test-org/test` at the set `inputs.spack-manifest-repository-ref` of `76f45ff6ea4694b5d1abce3b866e1b1d20ce4c4a` (the current `main`)