### PR TITLE
packages.spack.yaml: reduce the number of packages built in the CI Docker image

### DIFF
--- a/containers/upstream/dev/packages.spack.yaml
+++ b/containers/upstream/dev/packages.spack.yaml
@@ -1,32 +1,39 @@
 spack:
   definitions:
-    # List of packages to install in the upstream spack
-    - packages:
-      - gmake@4.4.1
-      - cmake@3.31.6
-      - openmpi@4.1.5
-      - openmpi@5.0.3
-      - netcdf-c@4.9.2
-      - netcdf-fortran@4.5.2
+  # List of packages to install in the upstream spack
+  - packages:
+    - netcdf-fortran@4.5.2
+
+  - deps:
+    - openmpi@4.1.5
+    - openmpi@5.0.3
 
     # Compilers to install the packages
-    - compilers:
-      - intel@2021.10.0
-      - oneapi@2025.2.0
-      - gcc@13.2.0
+  - compilers:
+    - intel@2021.10.0
+    - oneapi@2025.2.0
+    - gcc@13.2.0
 
     # Targets for the packages
-    - targets:
-      - target=x86_64
+  - targets:
+    - target=x86_64
+
   specs:
   # Combination of packages, compilers and targets for the final list of specs
   - matrix:
     - [$packages]
+    - [$^deps]
     - [$%compilers]
     - [$targets]
+
+  packages:
+    netcdf-c:
+      require:
+        - '@4.9.2'
+
   # Further specs can be installed in the usual way below, eg:
-  # - gmake%intel@2021.10.0 target=x86_64
-  # - python@3.11.7 %gcc
+  # - gmake %intel@2021.10.0 target=x86_64
+  # - python@3.11.13 %gcc@13.2.0 target=x86_64
   view: false  # No view required as these upstream packages are not loaded by users
   concretizer:
     unify: false  # No need to unify because there are combinations of the same package

--- a/containers/upstream/prod/packages.spack.yaml
+++ b/containers/upstream/prod/packages.spack.yaml
@@ -1,32 +1,39 @@
 spack:
   definitions:
-    # List of packages to install in the upstream spack
-    - packages:
-      - gmake@4.4.1
-      - cmake@3.31.6
-      - openmpi@4.1.5
-      - openmpi@5.0.3
-      - netcdf-c@4.9.2
-      - netcdf-fortran@4.5.2
+  # List of packages to install in the upstream spack
+  - packages:
+    - netcdf-fortran@4.5.2
+
+  - deps:
+    - openmpi@4.1.5
+    - openmpi@5.0.3
 
     # Compilers to install the packages
-    - compilers:
-      - intel@2021.10.0
-      - oneapi@2025.2.0
-      - gcc@13.2.0
+  - compilers:
+    - intel@2021.10.0
+    - oneapi@2025.2.0
+    - gcc@13.2.0
 
     # Targets for the packages
-    - targets:
-      - target=x86_64
+  - targets:
+    - target=x86_64
+
   specs:
   # Combination of packages, compilers and targets for the final list of specs
   - matrix:
     - [$packages]
+    - [$^deps]
     - [$%compilers]
     - [$targets]
+
+  packages:
+    netcdf-c:
+      require:
+        - '@4.9.2'
+
   # Further specs can be installed in the usual way below, eg:
-  # - gmake%intel@2021.10.0 target=x86_64
-  # - python@3.11.7 %gcc  target=x86_64
+  # - gmake %intel@2021.10.0 target=x86_64
+  # - python@3.11.13 %gcc@13.2.0 target=x86_64
   view: false  # No view required as these upstream packages are not loaded by users
   concretizer:
     unify: false  # No need to unify because there are combinations of the same package


### PR DESCRIPTION
### Problem

Too many packages are being built in the CI Docker image:
```
==> 254 installed packages
```
Also, some packages, e.g Openmpi and CMake, take a long time to build.

#### Openmpi
`openmpi@5.0.9` is being built without a requirement for it:
```
[root@acdc01110a94 opt]# spack find openmpi
-- linux-rocky8-x86_64 / %c,cxx,fortran=gcc@13.2.0 --------------
openmpi@4.1.5  openmpi@5.0.3  openmpi@5.0.9

-- linux-rocky8-x86_64 / %c,cxx,fortran=intel@2021.10.0 ---------
openmpi@4.1.5  openmpi@5.0.3  openmpi@5.0.9

-- linux-rocky8-x86_64 / %c,cxx,fortran=oneapi@2025.2.0 ---------
openmpi@4.1.5  openmpi@5.0.3  openmpi@5.0.9
==> 9 installed packages
```

#### CMake
CMake is being built multiple times for the same compiler:
```
[root@acdc01110a94 opt]# spack find cmake
-- linux-rocky8-x86_64 / %c,cxx=gcc@13.2.0 ----------------------
cmake@3.31.6  cmake@3.31.6

-- linux-rocky8-x86_64 / %c,cxx=gcc@8.5.0 -----------------------
cmake@3.31.6

-- linux-rocky8-x86_64 / %c,cxx=intel@2021.10.0 -----------------
cmake@3.31.6  cmake@3.31.6

-- linux-rocky8-x86_64 / %c,cxx=oneapi@2025.2.0 -----------------
cmake@3.31.6
==> 6 installed packages
```

### Solution
Spack doc https://spack.readthedocs.io/en/latest/environments.html#speclists-as-constraints , describes how to reduce the number of packages that are built. This PR along with PR https://github.com/ACCESS-NRI/spack-config/pull/98 , can reduce the CI Docker build to 170 installed packages.

```
[root@6183f4558e9b /]# spack find openmpi
-- linux-rocky8-x86_64 / %c,cxx,fortran=gcc@13.2.0 --------------
openmpi@4.1.5  openmpi@5.0.3

-- linux-rocky8-x86_64 / %c,cxx,fortran=intel@2021.10.0 ---------
openmpi@4.1.5  openmpi@5.0.3

-- linux-rocky8-x86_64 / %c,cxx,fortran=oneapi@2025.2.0 ---------
openmpi@4.1.5  openmpi@5.0.3
==> 6 installed packages
```

```
[root@6183f4558e9b /]# spack find cmake
-- linux-rocky8-x86_64 / %c,cxx=gcc@13.2.0 ----------------------
cmake@3.31.6

-- linux-rocky8-x86_64 / %c,cxx=gcc@8.5.0 -----------------------
cmake@3.31.6

-- linux-rocky8-x86_64 / %c,cxx=intel@2021.10.0 -----------------
cmake@3.31.6
==> 3 installed packages
```




