### PR TITLE
packages.spack.yaml: update netcdf-fortran version to 4.6.1

### DIFF
--- a/containers/upstream/dev/packages.spack.yaml
+++ b/containers/upstream/dev/packages.spack.yaml
@@ -2,7 +2,7 @@ spack:
   definitions:
   # List of packages to install in the upstream spack
   - packages:
-    - netcdf-fortran@4.5.2
+    - netcdf-fortran@4.6.1
 
   - deps:
     - openmpi@4.1.5

--- a/containers/upstream/prod/packages.spack.yaml
+++ b/containers/upstream/prod/packages.spack.yaml
@@ -2,7 +2,7 @@ spack:
   definitions:
   # List of packages to install in the upstream spack
   - packages:
-    - netcdf-fortran@4.5.2
+    - netcdf-fortran@4.6.1
 
   - deps:
     - openmpi@4.1.5


### PR DESCRIPTION
* Install the version required by ACCESS-OM2, ACCESS-OM3 and ACCESS-ESM1.6.