### PR TITLE
Update image name to :rocky-v1.1-2026.02.000

### DIFF
--- a/containers/compose.prod.yaml
+++ b/containers/compose.prod.yaml
@@ -9,7 +9,7 @@ x-common-args: &common-args
 services:
   upstream:
     container_name: Upstream
-    image: ghcr.io/access-nri/build-ci-upstream:rocky-v1.1-2025.12.000
+    image: ghcr.io/access-nri/build-ci-upstream:rocky-v1.1-2026.02.000
     tty: true
     build:
       context: .
@@ -27,7 +27,7 @@ services:
 
   runner:
     container_name: Runner
-    image: ghcr.io/access-nri/build-ci-runner:rocky-v1.1-2025.12.000
+    image: ghcr.io/access-nri/build-ci-runner:rocky-v1.1-2026.02.000
     tty: true
     depends_on:
     - upstream


### PR DESCRIPTION
## Background

Given https://github.com/ACCESS-NRI/build-ci/pull/271 and https://github.com/ACCESS-NRI/build-ci/pull/270 are merged, we need to update the image version. 

This will no longer need to be a manual process once https://github.com/ACCESS-NRI/build-ci/pull/263 is merged. 

## The PR

* Update the image name so we have provenance
