### PR TITLE
compilers.spack.yaml: workaround: gcc 10+ needs ~binutils

### DIFF
--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -66,7 +66,7 @@ RUN dnf update -y \
  && dnf clean all
 
 ################################################################################
-FROM opensuse/leap:15.5 AS base-os-suse
+FROM opensuse/leap:15.6 AS base-os-suse
 
 # csh currently required for some build scripts e.g. MOM5
 RUN zypper ref \

--- a/containers/upstream/dev/compilers.spack.yaml
+++ b/containers/upstream/dev/compilers.spack.yaml
@@ -4,7 +4,8 @@ spack:
   # We can't install compilers in a matrix, because we attempt to load each of the compilers in the speclist
   # when running spack-enable.bash
   specs:
-  - gcc@13.2.0 %gcc@8.5.0
+  # Workaround: https://github.com/spack/spack-packages/issues/3505
+  - gcc@13.2.0 ~binutils %gcc@8.5.0
   - intel-oneapi-compilers-classic@2021.10.0
   - intel-oneapi-compilers@2025.2.0
   view: false

--- a/containers/upstream/dev/packages.spack.yaml
+++ b/containers/upstream/dev/packages.spack.yaml
@@ -26,14 +26,13 @@ spack:
     - [$%compilers]
     - [$targets]
 
+  - python@3.11 target=x86_64 %gcc@13.2.0
+
   packages:
     netcdf-c:
       require:
         - '@4.9.2'
 
-  # Further specs can be installed in the usual way below, eg:
-  # - gmake %intel@2021.10.0 target=x86_64
-  # - python@3.11.13 %gcc@13.2.0 target=x86_64
   view: false  # No view required as these upstream packages are not loaded by users
   concretizer:
     unify: false  # No need to unify because there are combinations of the same package

--- a/containers/upstream/prod/compilers.spack.yaml
+++ b/containers/upstream/prod/compilers.spack.yaml
@@ -4,7 +4,8 @@ spack:
   # We can't install compilers in a matrix, because we attempt to load each of the compilers in the speclist
   # when running spack-enable.bash
   specs:
-  - gcc@13.2.0 %gcc@8.5.0
+  # Workaround: https://github.com/spack/spack-packages/issues/3505
+  - gcc@13.2.0 ~binutils %gcc@8.5.0
   - intel-oneapi-compilers-classic@2021.10.0
   - intel-oneapi-compilers@2025.2.0
   view: false

--- a/containers/upstream/prod/packages.spack.yaml
+++ b/containers/upstream/prod/packages.spack.yaml
@@ -26,14 +26,13 @@ spack:
     - [$%compilers]
     - [$targets]
 
+  - python@3.11 target=x86_64 %gcc@13.2.0
+
   packages:
     netcdf-c:
       require:
         - '@4.9.2'
 
-  # Further specs can be installed in the usual way below, eg:
-  # - gmake %intel@2021.10.0 target=x86_64
-  # - python@3.11.13 %gcc@13.2.0 target=x86_64
   view: false  # No view required as these upstream packages are not loaded by users
   concretizer:
     unify: false  # No need to unify because there are combinations of the same package


### PR DESCRIPTION
* packages.spack.yaml: install the newest Python 3.11 release