### PR TITLE
Consolidate `yq` and `tmate` installs into a post-`base-spack` stage

### DIFF
--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -189,7 +189,7 @@ SHELL ["docker-shell"]
 RUN spack bootstrap now
 
 ################################################################################
-FROM base-spack AS common-additional-tools
+FROM base-spack AS base-ci
 
 # Install tmate in the image for remote access during workflows via mxschmitt/action-tmate
 RUN <<EOF
@@ -204,7 +204,7 @@ RUN curl -L https://github.com/mikefarah/yq/releases/download/v4.45.1/yq_linux_a
 
 ################################################################################
 # Install compilers and other common packages for the upstream image
-FROM common-additional-tools AS upstream
+FROM base-ci AS upstream
 
 LABEL org.opencontainers.image.source=https://github.com/ACCESS-NRI/build-ci
 
@@ -271,7 +271,7 @@ EOF
 
 ################################################################################
 # Set up the lightweight spack image that uses the upstream image
-FROM common-additional-tools AS runner
+FROM base-ci AS runner
 
 LABEL org.opencontainers.image.source=https://github.com/ACCESS-NRI/build-ci
 

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -56,8 +56,9 @@ RUN dnf update -y \
     xz \
     zstd \
  # Install gh
- && curl -fsSL https://cli.github.com/packages/rpm/gh-cli.repo | tee /etc/yum.repos.d/github-cli.repo \
- && dnf -y install gh \
+ && dnf -y install 'dnf-command(config-manager)' \
+ && dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo \
+ && dnf -y install gh --repo gh-cli \
  # dnf cleanup
  && rm -rf /var/cache/dnf \
  && dnf clean all

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -1,7 +1,7 @@
-# Copyright 2023-2025 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# Copyright 2023-2026 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Contains build targets: base-os-rocky, base-os-suse, base-spack, ci, dev
+# Contains build targets: base-os-rocky, base-os-suse, base-spack, base-ci, upstream, runner
 
 ################################################################################
 # OS = {rocky,suse}

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -112,21 +112,7 @@ RUN zypper ref \
  &&  zypper clean
 
 ################################################################################
-FROM base-os-$OS AS common-additional-tools
-
-# Install tmate in the image for remote access during workflows via mxschmitt/action-tmate
-RUN <<EOF
-curl -L https://github.com/tmate-io/tmate/releases/download/2.4.0/tmate-2.4.0-static-linux-amd64.tar.xz -o static-tmate.tar.xz
-tar -xvf static-tmate.tar.xz --strip-components=1
-mv tmate /usr/local/bin/tmate
-rm -rf static-tmate.tar.xz
-EOF
-
- # Install yq for manifest interrogation
-RUN curl -L https://github.com/mikefarah/yq/releases/download/v4.45.1/yq_linux_amd64 -o /usr/bin/yq && chmod +x /usr/bin/yq
-
-################################################################################
-FROM common-additional-tools AS base-spack
+FROM base-os-$OS AS base-spack
 
 ARG SPACK_GIT_URL=https://github.com/ACCESS-NRI/spack.git
 # Default spack version - must be changed across ci*.yml as well
@@ -202,8 +188,22 @@ SHELL ["docker-shell"]
 RUN spack bootstrap now
 
 ################################################################################
+FROM base-spack AS common-additional-tools
+
+# Install tmate in the image for remote access during workflows via mxschmitt/action-tmate
+RUN <<EOF
+curl -L https://github.com/tmate-io/tmate/releases/download/2.4.0/tmate-2.4.0-static-linux-amd64.tar.xz -o static-tmate.tar.xz
+tar -xvf static-tmate.tar.xz --strip-components=1
+mv tmate /usr/local/bin/tmate
+rm -rf static-tmate.tar.xz
+EOF
+
+ # Install yq for manifest interrogation
+RUN curl -L https://github.com/mikefarah/yq/releases/download/v4.45.1/yq_linux_amd64 -o /usr/bin/yq && chmod +x /usr/bin/yq
+
+################################################################################
 # Install compilers and other common packages for the upstream image
-FROM base-spack AS upstream
+FROM common-additional-tools AS upstream
 
 LABEL org.opencontainers.image.source=https://github.com/ACCESS-NRI/build-ci
 
@@ -270,7 +270,7 @@ EOF
 
 ################################################################################
 # Set up the lightweight spack image that uses the upstream image
-FROM base-spack AS runner
+FROM common-additional-tools AS runner
 
 LABEL org.opencontainers.image.source=https://github.com/ACCESS-NRI/build-ci
 

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -55,9 +55,6 @@ RUN dnf update -y \
     which \
     xz \
     zstd \
- # Install yq
- && curl -L https://github.com/mikefarah/yq/releases/download/v4.45.1/yq_linux_amd64 -o /usr/bin/yq \
- && chmod +x /usr/bin/yq \
  # Install gh
  && curl -fsSL https://cli.github.com/packages/rpm/gh-cli.repo | tee /etc/yum.repos.d/github-cli.repo \
  && dnf -y install gh \
@@ -107,9 +104,6 @@ RUN zypper ref \
     subversion \
     tcsh \
     vim \
- # Install yq
- && curl -L https://github.com/mikefarah/yq/releases/download/v4.45.1/yq_linux_amd64 -o /usr/bin/yq \
- && chmod +x /usr/bin/yq \
  # Install gh
  && zypper addrepo https://cli.github.com/packages/rpm/gh-cli.repo \
  && zypper ref \
@@ -117,9 +111,22 @@ RUN zypper ref \
  # zypper cleanup
  &&  zypper clean
 
+################################################################################
+FROM base-os-$OS AS common-additional-tools
+
+# Install tmate in the image for remote access during workflows via mxschmitt/action-tmate
+RUN <<EOF
+curl -L https://github.com/tmate-io/tmate/releases/download/2.4.0/tmate-2.4.0-static-linux-amd64.tar.xz -o static-tmate.tar.xz
+tar -xvf static-tmate.tar.xz --strip-components=1
+mv tmate /usr/local/bin/tmate
+rm -rf static-tmate.tar.xz
+EOF
+
+ # Install yq for manifest interrogation
+RUN curl -L https://github.com/mikefarah/yq/releases/download/v4.45.1/yq_linux_amd64 -o /usr/bin/yq && chmod +x /usr/bin/yq
 
 ################################################################################
-FROM base-os-$OS AS base-spack
+FROM common-additional-tools AS base-spack
 
 ARG SPACK_GIT_URL=https://github.com/ACCESS-NRI/spack.git
 # Default spack version - must be changed across ci*.yml as well
@@ -195,8 +202,10 @@ SHELL ["docker-shell"]
 RUN spack bootstrap now
 
 ################################################################################
-# Install compilers and other common packages
-FROM base-spack AS base-upstream
+# Install compilers and other common packages for the upstream image
+FROM base-spack AS upstream
+
+LABEL org.opencontainers.image.source=https://github.com/ACCESS-NRI/build-ci
 
 # Install compilers and low-level, common packages
 COPY ${SOURCE_COMPILERS_SPACK_MANIFEST} ${ENV_COMPILERS_SPACK_MANIFEST}
@@ -259,31 +268,11 @@ if [ -n "$REQUESTS_OCI_MIRROR" ]; then
 fi
 EOF
 
-FROM base-upstream AS upstream
-
-LABEL org.opencontainers.image.source=https://github.com/ACCESS-NRI/build-ci
-
-# Install tmate in the image for remote access during workflows via mxschmitt/action-tmate
-RUN <<EOF
-curl -L https://github.com/tmate-io/tmate/releases/download/2.4.0/tmate-2.4.0-static-linux-amd64.tar.xz -o static-tmate.tar.xz
-tar -xvf static-tmate.tar.xz --strip-components=1
-mv tmate /usr/local/bin/tmate
-rm -rf static-tmate.tar.xz
-EOF
-
-
 ################################################################################
+# Set up the lightweight spack image that uses the upstream image
 FROM base-spack AS runner
 
 LABEL org.opencontainers.image.source=https://github.com/ACCESS-NRI/build-ci
-
-# Install tmate in the image for remote access during workflows via mxschmitt/action-tmate
-RUN <<EOF
-curl -L https://github.com/tmate-io/tmate/releases/download/2.4.0/tmate-2.4.0-static-linux-amd64.tar.xz -o static-tmate.tar.xz
-tar -xvf static-tmate.tar.xz --strip-components=1
-mv tmate /usr/local/bin/tmate
-rm -rf static-tmate.tar.xz
-EOF
 
 # Set up ACCESS Spack buildcache
 RUN spack mirror add --scope=site --autopush --unsigned runner_set_buildcache /opt/runner_set_buildcache

--- a/containers/compose.prod.yaml
+++ b/containers/compose.prod.yaml
@@ -9,7 +9,7 @@ x-common-args: &common-args
 services:
   upstream:
     container_name: Upstream
-    image: ghcr.io/access-nri/build-ci-upstream:rocky-v1.1-2026.02.001
+    image: ghcr.io/access-nri/build-ci-upstream:rocky-v1.1-2026.02.002
     tty: true
     build:
       context: .
@@ -27,7 +27,7 @@ services:
 
   runner:
     container_name: Runner
-    image: ghcr.io/access-nri/build-ci-runner:rocky-v1.1-2026.02.001
+    image: ghcr.io/access-nri/build-ci-runner:rocky-v1.1-2026.02.002
     tty: true
     depends_on:
     - upstream


### PR DESCRIPTION
Closes #275

## Background

There is a bit of duplication in the Dockerfile - specifically regarding `tmate` and `yq`. 

This PR consolidates installation of these tools into a `common-additional-tools` stage, post-`base-spack` but pre-`upstream|runner`. This removes the `base-upstream` stage, as the dev image may be it's own Dockerfile. 

## The PR

* Consolidate `yq` and `tmate` into `base-ci` stage

## Testing

Tested the build locally, newly added stages work fine. Will push up `ghcr.io/access-nri/build-ci-[runner|upstream]:rocky-v1.1-2026.02.002` upon merge. 
