### PR TITLE
Update Image to `2026.02.003` (Includes `access-spack-packages` directory change)

### DIFF
--- a/containers/compose.prod.yaml
+++ b/containers/compose.prod.yaml
@@ -9,7 +9,7 @@ x-common-args: &common-args
 services:
   upstream:
     container_name: Upstream
-    image: ghcr.io/access-nri/build-ci-upstream:rocky-v1.1-2026.02.002
+    image: ghcr.io/access-nri/build-ci-upstream:rocky-v1.1-2026.02.003
     tty: true
     build:
       context: .
@@ -27,7 +27,7 @@ services:
 
   runner:
     container_name: Runner
-    image: ghcr.io/access-nri/build-ci-runner:rocky-v1.1-2026.02.002
+    image: ghcr.io/access-nri/build-ci-runner:rocky-v1.1-2026.02.003
     tty: true
     depends_on:
     - upstream


### PR DESCRIPTION
## Background

See https://github.com/ACCESS-NRI/spack-config/pull/103 and https://github.com/ACCESS-NRI/access-spack-packages/pull/389

We are moving `access-spack-packages` from a spack-managed location back to a place users expect: `$spack/../access-spack-packages`. This PR rebuilds the image with the directory in the regular place, so we don't have to re-copy the directory once `spack-config` is updated. 

## The PR

* Update image to `rocky-v1.1-2026.02.003`, post-`spack-config` update that updated the location of `access-spack-packages`. 
