### PR TITLE
Accept `spack config get repos` keys with and without `:`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,7 +333,8 @@ jobs:
         # from spack-config's repos.yaml or use "develop" (the default branch) if not specified there either.
         run: |
           . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
-          ref=$(spack config get repos | yq '.repos.builtin | .branch // .tag // .commit // "develop"')
+          # Accept both the overridden .builtin: and regular .builtin key. See ACCESS-NRI/spack-config#105 for more info.
+          ref=$(spack config get repos | yq '.repos | .builtin // ."builtin:" | .branch // .tag // .commit // "develop"')
           echo "Default builtin-spack-packages-ref is $ref"
           echo "ref=$ref" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
References ACCESS-NRI/spack-config#105

## Background

The repo name keys in the output of `spack config get` are in the form of either just the key name (`foo`), or of the overriden key name (`foo:`). While we get guidance if this extra `:` is supposed to be stripped from the output of `spack config get` as it is in `spack config blame`, we need to accept both of them, so we don't always drill down to the last-resort case of `"develop"` in `build-ci` runs, which is an unstable branch. 

## The PR

* Accept both `.builtin` and `.builtin:` keys when determining the default builtin spack packages ref for `build-ci`. 


## Testing

Both tested with the common setup of:

```sh
$ docker run -it --rm ghcr.io/access-nri/build-ci-upstream:rocky-v1.1-2026.03.000-test
$ . /opt/spack/share/spack/setup-env.sh
```

### Works with keys with `:`

```sh
$ spack config get repos
repos:
  'access_spack_packages:':
    git: https://github.com/ACCESS-NRI/access-spack-packages.git
    branch: api-v2
    destination: $spack/../access-spack-packages
  'builtin:':
    git: https://github.com/spack/spack-packages.git
    # gnu packages: bump (#3390)
    commit: 383e969358c951abe17623696083e6f862c4488e

$ spack config get repos | yq '.repos | .builtin // ."builtin:" | .branch // .tag // .commit // "develop"'
383e969358c951abe17623696083e6f862c4488e
# Note it is not 'develop'!
```

### Works with keys without `:`

```sh
$ git -C /opt/spack-config checkout HEAD~  # AKA, the commit that had no '::'
$ spack config get repos
repos:
  access_spack_packages:
    git: https://github.com/ACCESS-NRI/access-spack-packages.git
    branch: api-v2
    destination: $spack/../access-spack-packages
  builtin:
    git: https://github.com/spack/spack-packages.git
    # gnu packages: bump (#3390)
    commit: 383e969358c951abe17623696083e6f862c4488e

$ spack config get repos | yq '.repos | .builtin // ."builtin:" | .branch // .tag // .commit // "develop"'
383e969358c951abe17623696083e6f862c4488e
```