### PR TITLE
Move `spack-config` scope from `spack` to `site`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,7 +316,7 @@ jobs:
             exit 2
           fi
 
-          ln --symbolic --relative --verbose --force ${{ steps.env.outputs.SPACK_ROOT }}/../spack-config/${spack_branch}/ci-runner/* ${{ steps.env.outputs.SPACK_ROOT }}/etc/spack/
+          ln --symbolic --relative --verbose --force ${{ steps.env.outputs.SPACK_ROOT }}/../spack-config/${spack_branch}/ci-runner/* ${{ steps.env.outputs.SPACK_ROOT }}/etc/spack/site
 
       - name: Spack - Initial Enable
         run: |

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -264,7 +264,7 @@ RUN --mount=type=secret,id=oci-username,env=OCI_USERNAME \
 if [ -n "$OCI_USERNAME" ] || [ -n "$OCI_PASSWORD" ] || [ -n "$OCI_URL" ]; then
   REQUESTS_OCI_MIRROR=1
   spack mirror add \
-    --scope=site \
+    --scope=spack \
     --autopush \
     --unsigned \
     --oci-username-variable OCI_USERNAME \
@@ -281,7 +281,7 @@ spack env deactivate
 spack clean --downloads --stage
 
 if [ -n "$REQUESTS_OCI_MIRROR" ]; then
-  spack mirror remove --scope=site docker_build_buildcache
+  spack mirror remove --scope=spack docker_build_buildcache
 fi
 EOF
 
@@ -295,7 +295,7 @@ RUN --mount=type=secret,id=oci-username,env=OCI_USERNAME \
 if [ -n "$OCI_USERNAME" ] || [ -n "$OCI_PASSWORD" ] || [ -n "$OCI_URL" ]; then
   REQUESTS_OCI_MIRROR=1
   spack mirror add \
-    --scope=site \
+    --scope=spack \
     --autopush \
     --unsigned \
     --oci-username-variable OCI_USERNAME \
@@ -312,7 +312,7 @@ spack env deactivate
 spack clean --downloads --stage
 
 if [ -n "$REQUESTS_OCI_MIRROR" ]; then
-  spack mirror remove --scope=site docker_build_buildcache
+  spack mirror remove --scope=spack docker_build_buildcache
 fi
 EOF
 
@@ -323,7 +323,7 @@ FROM base-ci AS runner
 LABEL org.opencontainers.image.source=https://github.com/ACCESS-NRI/build-ci
 
 # Set up ACCESS Spack buildcache
-RUN spack mirror add --scope=site --autopush --unsigned runner_set_buildcache /opt/runner_set_buildcache
+RUN spack mirror add --scope=spack --autopush --unsigned runner_set_buildcache /opt/runner_set_buildcache
 
 
 ENTRYPOINT ["/bin/bash", "/opt/spack/share/spack/docker/entrypoint.bash"]

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -150,6 +150,12 @@ LABEL au.org.access-nri.image.spack-config-repo-version=${SPACK_CONFIG_REPO_VERS
 SHELL ["/bin/bash", "-c"]
 
 # Install spack
+
+# In the transition between spack v0.X and v1.X, scopes were changed:
+# The 'site' scope was moved: $spack/etc/spack -> $spack/etc/spack/site
+# The old $spack/etc/spack scope is a new scope called 'spack'
+# Scope precedence is now: spack > user > site, so we need to move our spack-config scope
+# to 'site' so we can use the 'user' scope appropriately again.
 RUN <<EOF
 git clone ${SPACK_GIT_URL} ${SPACK_ROOT} --branch ${SPACK_REPO_VERSION}
 
@@ -157,7 +163,12 @@ git clone ${SPACK_GIT_URL} ${SPACK_ROOT} --branch ${SPACK_REPO_VERSION}
 git clone  https://github.com/ACCESS-NRI/spack-config.git /opt/spack-config --branch ${SPACK_CONFIG_REPO_VERSION}
 
 # Exit with ENOENT 2 "No such file or directory", if the directory does not exist
-if [ -d "${SPACK_CONFIG_DIR}" ]; then ln -s -r -v ${SPACK_CONFIG_DIR}/* ${SPACK_ROOT}/etc/spack/; else echo "${SPACK_CONFIG_DIR} does not exist!"; exit 2; fi
+if [ -d "${SPACK_CONFIG_DIR}" ]; then
+  ln -s -r -v ${SPACK_CONFIG_DIR}/* ${SPACK_ROOT}/etc/spack/site/
+else
+  echo "${SPACK_CONFIG_DIR} does not exist!"
+  exit 2
+fi
 EOF
 
 # Enables setting Spack setup type via SHELL command

--- a/containers/compose.prod.yaml
+++ b/containers/compose.prod.yaml
@@ -9,7 +9,7 @@ x-common-args: &common-args
 services:
   upstream:
     container_name: Upstream
-    image: ghcr.io/access-nri/build-ci-upstream:rocky-v1.1-2026.02.003
+    image: ghcr.io/access-nri/build-ci-upstream:rocky-v1.1-2026.03.000
     tty: true
     build:
       context: .
@@ -27,7 +27,7 @@ services:
 
   runner:
     container_name: Runner
-    image: ghcr.io/access-nri/build-ci-runner:rocky-v1.1-2026.02.003
+    image: ghcr.io/access-nri/build-ci-runner:rocky-v1.1-2026.03.000
     tty: true
     depends_on:
     - upstream


### PR DESCRIPTION
Closes #286
Required by #268

## Background

In the transition from `spack v0.X` to `spack v1.X`, we missed that the `$spack/etc/spack` scope was changed from `site` to `spack`. `spack` it a very high precedence scope, which overshadows `user`. We need the `user` scope for `build-ci`. Hence, we need to change our `spack-config` symlinks back to `site` (AKA, `$spack/etc/spack/site`).

## The PR

* Symlink `spack-config` configuration info to `$spack/etc/spack/site` in both the Dockerfile and the workflow

## Testing

Built successfully via https://github.com/ACCESS-NRI/build-ci/actions/runs/22986676141.

`user` scope modifications worked appropriately via `spack config --scope=user add upstreams:hi:install_tree:/opt/somewhere`
