### PR TITLE
GitHub Spack Cache Eviction Strategy

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -308,3 +308,9 @@ This workflow deletes package from a GitHub-based Spack Buildcache for the purpo
 ### Outputs
 
 None in GitHub Actions, but the entries are deleted from the buildcache.
+
+## `scheduled-cache-eviction.yml` - Scheduled Eviction Of Entries From `ACCESS-NRI` `build-ci-buildcache`
+
+### Overview
+
+Scheduled trigger for the eviction of stale entries in the buildcache. Calls [`github-cache-eviction.yml`](#github-cache-evictionyml---evict-entries-from-a-github-spack-buildcache-based-on-date-modified).

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -297,7 +297,7 @@ This workflow deletes package from a GitHub-based Spack Buildcache for the purpo
 | ---- | ---- | ----------- | -------- | ------- | ------- |
 | `buildcache-package-org` | `string` | Organisation that owns the package that is used as an OCI-backed spack buildcache | `true` | N/A | `ACCESS-NRI`, `some-org` |
 | `buildcache-package-name` | `string` | Name of the package that is used as an OCI-backed spack buildcache | `true` | N/A | `build-ci-buildcache`, `custom-buildcache` |
-| `eviction-threshold` | `number` (days) | Number of days after which a buildcache entry is considered stale and can be evicted | `true` | `90` | `30`, `90`, `365` |
+| `eviction-threshold-days` | `number` (days) | Number of days after which a buildcache entry is considered stale and can be evicted | `true` | `90` | `30`, `90`, `365` |
 
 ### Secrets
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,12 +1,16 @@
-# Entrypoint Workflows
+# Workflows
 
-## `ci.yml` - Build and Test Workflow Entrypoint
+## Entrypoint Workflows
 
-### Overview
+Entrypoint workflows are reusable workflows that are the starting point for the build and test framework.
+
+### `ci.yml` - Build and Test Workflow Entrypoint
+
+#### Overview
 
 This workflow handles building and running short CI tests on a given spack manifest. It offers customisation of `spack`, `spack-config`, and spack packages repos, and allows SSH access to the installation to the author of the PR.
 
-### Inputs
+#### Inputs
 
 | Name | Type | Description | Required | Default | Example |
 | ---- | ---- | ----------- | -------- | ------- | ------- |
@@ -25,14 +29,14 @@ This workflow handles building and running short CI tests on a given spack manif
 | `spack-oci-buildcache-url` | `string` (OCI URL) | The URL to an oci-backed buildcache, available in spack >= v1.0. OCI-backed buildcaches are the only option for GitHub-hosted CI, and can be used as a backup for self-hosted CI's runner buildcache | `false` | N/A | `"oci://ghcr.io/ACCESS-NRI/build-ci-buildcache"`, `"oci://ghcr.io/ORG/IMAGE"` |
 | `run-self-hosted` | `boolean` | Whether to run the job on a self-hosted runner. For security, workflow runs will hang if this is `true` but it is not using a valid `v*` branch or tag for the workflow ref | `false` | `true` | `true`, `false` |
 
-#### Future Inputs
+##### Future Inputs
 
 | Name | Type | Description | Required | Default | Example |
 | ---- | ---- | ----------- | -------- | ------- | ------- |
 | `pytest-test-directory-path` | `string` (Directory path relative to component repository root) | Directory path in the caller model component repository that contains pytests to run against the built manifests | `false` | N/A | `".github/build/tests/"` |
 | `pytest-test-markers` | `string` (Pytest-style markers) | A string of pytest markers to use to filter tests in the caller model component repository | `false` | `""` (runs all tests) | `"not slow and not mpi"` |
 
-### Secrets
+#### Secrets
 
 | Name | Type | Description | Required | Default | Example |
 | ---- | ---- | ----------- | -------- | ------- | ------- |
@@ -41,7 +45,7 @@ This workflow handles building and running short CI tests on a given spack manif
 
 | `spack-oci-buildcache-password` | `string` (GitHub Personal Access Token if `oci://ghcr.io`) | A password (or GitHub PAT for `oci://ghcr.io` buildcaches) to use for reading and writing to the spack OCI buildcache, if `inputs.spack-oci-buildcache-url` is defined | `false` (attempts with `secrets.GITHUB_TOKEN`) | N/A | `"github_pat_XXXXX"` |
 
-### Outputs
+#### Outputs
 
 | Name | Type | Description | Example |
 | ---- | ---- | ----------- | ------- |
@@ -56,15 +60,15 @@ This workflow handles building and running short CI tests on a given spack manif
 | `artifact-pattern` | `string` (glob) | Wildcard pattern to match all artifacts across a matrix job | `'output-*'` |
 | `artifact-url` | `string` (URL) | The URL of the artifact | `"https://github.com/ACCESS-NRI/MOM5/actions/runs/15890554355/artifacts/3406449135"` |
 
-#### Future Outputs
+##### Future Outputs
 
 | Name | Type | Description | Example |
 | ---- | ---- | ----------- | ------- |
 | `test-artifact-url` | `string` (URL) | The URL of the pytest result artifact | `"https://github.com/ACCESS-NRI/MOM5/actions/runs/15890554355/artifacts/3406449136"` |
 
-### Examples
+#### Examples
 
-#### Minimal
+##### Minimal
 
 ```yaml
 jobs:
@@ -74,7 +78,7 @@ jobs:
       spack-manifest-path: .github/build/spack.yaml.j2
 ```
 
-#### Complex
+##### Complex
 
 ```yaml
 jobs:
@@ -96,7 +100,7 @@ jobs:
       spack-install-command-pat: ${{ secrets.GH_PAT }}
 ```
 
-#### Simple Matrix
+##### Simple Matrix
 
 ```yaml
 jobs:
@@ -117,7 +121,7 @@ jobs:
       spack-manifest-path: ${{ matrix.manifest }}
 ```
 
-#### Complex Matrix (Each Element With Multiple Attributes)
+##### Complex Matrix (Each Element With Multiple Attributes)
 
 ```yaml
 jobs:
@@ -138,7 +142,7 @@ jobs:
       spack-compiler-manifest-path: ${{ matrix.values.compiler }}
 ```
 
-#### Complex Matrix (Each Element As A Combination of Attributes)
+##### Complex Matrix (Each Element As A Combination of Attributes)
 
 ```yaml
 jobs:
@@ -156,9 +160,9 @@ jobs:
       spack-compiler-manifest-path: ${{ matrix.values.compiler }}
 ```
 
-### More Information
+#### More Information
 
-#### Jinja Templates and Data
+##### Jinja Templates and Data
 
 The `inputs.spack-manifest-path` is a path to a jinja-templatable spack manifest.
 
@@ -205,7 +209,7 @@ spack:
   - 'mom5@git.u2re8e3 %intel@2021.10.0'
 ```
 
-#### Compiler Spack Manifests
+##### Compiler Spack Manifests
 
 We use an upstream spack installation that contains common compilers used. If one wants to use other compilers that have not yet been added to that upstream spack, they can add a spack manifest that installs compilers before installing the given model component spack manifest, through `inputs.spack-compiler-manifest-path`.
 
@@ -222,7 +226,7 @@ spack:
     unify: false
 ```
 
-#### Using outputs of a Matrix Job
+##### Using outputs of a Matrix Job
 
 If you need to aggregate data across multiple instances of a matrix job, you will need to use the `job-output-artifact-pattern` output rather than individual job outputs through `needs`, due to GitHubs insistence of jobs overwriting the sole matrix job output. This pattern, when used as an argument to `actions/download-artifact`, will have all the inputs, outputs and conclusion of each instance of the matrix job, in JSON. In a dependent later job, you will need to merge all these artifacts together and parse them. For example:
 
@@ -259,15 +263,17 @@ jobs:
         done
 ```
 
-## `containers-ci.yml` - Build and Push `build-ci-[upstream|runner]` Images
+## Other Workflows
 
-### Overview
+### `containers-ci.yml` - Build and Push `build-ci-[upstream|runner]` Images
+
+#### Overview
 
 This workflow handles building and pushing of images used in `ci.yml` on push to `v*`, or via `workflow_dispatch`.
 
 It stands up and tears down an ephemeral, powerful Nectar VM that builds the image via docker.
 
-### Inputs (via `workflow_dispatch`)
+#### Inputs (via `workflow_dispatch`)
 
 | Name | Type | Description | Required | Default | Example |
 | ---- | ---- | ----------- | -------- | ------- | ------- |
@@ -275,6 +281,30 @@ It stands up and tears down an ephemeral, powerful Nectar VM that builds the ima
 | `pr-for-comment` | `string` (PR Number) | Comment the build result to this PR number | `false` | N/A | `12` |
 | `push` | `boolean` | Whether to push the given image once built. Will overwrite image if tags are the same | `true` | `false` | `true` or `false` |
 
-### Outputs
+#### Outputs
 
 None in GitHub Actions, but the image created by `containers/compose.yaml` is pushed to `ghcr.io`.
+
+## `github-cache-eviction.yml` - Evict Entries From A GitHub Spack Buildcache Based On Date Modified
+
+### Overview
+
+This workflow deletes package from a GitHub-based Spack Buildcache for the purposes of evicting old, unused entries from the cache.
+
+### Inputs
+
+| Name | Type | Description | Required | Default | Example |
+| ---- | ---- | ----------- | -------- | ------- | ------- |
+| `buildcache-package-org` | `string` | Organisation that owns the package that is used as an OCI-backed spack buildcache | `true` | N/A | `ACCESS-NRI`, `some-org` |
+| `buildcache-package-name` | `string` | Name of the package that is used as an OCI-backed spack buildcache | `true` | N/A | `build-ci-buildcache`, `custom-buildcache` |
+| `eviction-threshold` | `number` (days) | Number of days after which a buildcache entry is considered stale and can be evicted | `true` | `90` | `30`, `90`, `365` |
+
+### Secrets
+
+| Name | Type | Description | Required | Default | Example |
+| ---- | ---- | ----------- | -------- | ------- | ------- |
+| `token` | `string` (GitHub token / PAT) | GitHub token with permissions to delete packages in the registry, typically a PAT with `delete:packages` scope. This is needed to delete old buildcache entries from the OCI registry. | `true` | N/A | `gh_pat_XXX...` |
+
+### Outputs
+
+None in GitHub Actions, but the entries are deleted from the buildcache.

--- a/.github/workflows/github-cache-eviction.yml
+++ b/.github/workflows/github-cache-eviction.yml
@@ -12,7 +12,7 @@ on:
         required: true
         description: |
           Name of the package that is used as an OCI-backed spack buildcache
-      eviction-threshold:
+      eviction-threshold-days:
         type: number
         required: true
         description: |
@@ -30,11 +30,11 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.token }}
     steps:
-      - name: Get all entries in buildcache older than ${{ inputs.eviction-threshold }} days
+      - name: Get all entries in buildcache older than ${{ inputs.eviction-threshold-days }} days
         id: entries
         # The date format is ISO 8601 date/time string with a literal Z for UTC - as GitHub uses. Eg. 2025-08-07T01:50:59Z
         run: |
-          eviction_time=$(date --universal --date "-${{ inputs.eviction-threshold }} days" +%FT%TZ)
+          eviction_time=$(date --universal --date "-${{ inputs.eviction-threshold-days }} days" +%FT%TZ)
           echo "::notice::Evicting entries older than ${eviction_time}"
 
           # See https://docs.github.com/en/rest/packages/packages?apiVersion=2026-03-10#list-package-versions-for-a-package-owned-by-an-organization
@@ -58,7 +58,7 @@ jobs:
 
           echo "eviction-ids=$eviction_ids" >> $GITHUB_OUTPUT
 
-      - name: Evict entries in buildcache older than ${{ inputs.eviction-threshold }} days
+      - name: Evict entries in buildcache older than ${{ inputs.eviction-threshold-days }} days
         run: |
           for entry in ${{ steps.entries.outputs.eviction-ids }}; do
             echo "Evicting $entry..."

--- a/.github/workflows/github-cache-eviction.yml
+++ b/.github/workflows/github-cache-eviction.yml
@@ -1,0 +1,69 @@
+name: Github Cache Eviction
+on:
+  workflow_call:
+    inputs:
+      buildcache-package-org:
+        type: string
+        required: true
+        description: |
+          Organisation that owns the package that is used as an OCI-backed spack buildcache
+      buildcache-package-name:
+        type: string
+        required: true
+        description: |
+          Name of the package that is used as an OCI-backed spack buildcache
+      eviction-threshold:
+        type: number
+        required: true
+        description: |
+          Number of days after which a buildcache entry is considered stale and can be evicted
+    secrets:
+      token:
+        required: true
+        description: |
+          GitHub token with permissions to delete packages in the registry, typically a PAT with `delete:packages` scope.
+          This is needed to delete old buildcache entries from the OCI registry.
+jobs:
+  eviction:
+    name: Evict Old Entries
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.token }}
+    steps:
+      - name: Get all entries in buildcache older than ${{ inputs.eviction-threshold }} days
+        id: entries
+        # The date format is ISO 8601 date/time string with a literal Z for UTC - as GitHub uses. Eg. 2025-08-07T01:50:59Z
+        run: |
+          eviction_time=$(date --universal --date "-${{ inputs.eviction-threshold }} days" +%FT%TZ)
+          echo "::notice::Evicting entries older than ${eviction_time}"
+
+          # See https://docs.github.com/en/rest/packages/packages?apiVersion=2026-03-10#list-package-versions-for-a-package-owned-by-an-organization
+          gh api --paginate --slurp \
+            /orgs/${{ inputs.buildcache-package-org }}/packages/container/${{ inputs.buildcache-package-name }}/versions
+            > versions.json
+
+          jq --compact-output --raw-output --arg e "$eviction_time" \
+            '[.[][] | select(.modified_at < $e)]' \
+            versions.json
+            > evictions.json
+
+          eviction_ids=$(jq --compact-output --raw-output \
+            '[.[] | .id] | join(" ")'
+            evictions.json
+          )
+
+          number_of_evictions=$(wc -w <<< "$eviction_ids")
+          eviction_descriptions=$(jq '[.[] | .description] | @sh' evictions.json)"
+          echo "::warning::Going to delete the following ${number_of_evictions} entries: ${eviction_descriptions}"
+
+          echo "eviction-ids=$eviction_ids" >> $GITHUB_OUTPUT
+
+      - name: Evict entries in buildcache older than ${{ inputs.eviction-threshold }} days
+        run: |
+          for entry in ${{ steps.entries.outputs.eviction-ids }}; do
+            echo "Evicting $entry..."
+
+            # See https://docs.github.com/en/rest/packages/packages?apiVersion=2026-03-10#delete-package-version-for-an-organization
+            gh api --method DELETE \
+              /orgs/${{ inputs.buildcache-package-org }}/packages/container/${{ inputs.buildcache-package-name }}/versions/$entry
+          done

--- a/.github/workflows/github-cache-eviction.yml
+++ b/.github/workflows/github-cache-eviction.yml
@@ -35,7 +35,7 @@ jobs:
         # The date format is ISO 8601 date/time string with a literal Z for UTC - as GitHub uses. Eg. 2025-08-07T01:50:59Z
         run: |
           eviction_time=$(date --universal --date "-${{ inputs.eviction-threshold-days }} days" +%FT%TZ)
-          echo "::notice::Evicting entries older than ${eviction_time}"
+          echo "::notice::Evicting entries last-updated before ${eviction_time}"
 
           # See https://docs.github.com/en/rest/packages/packages?apiVersion=2026-03-10#list-package-versions-for-a-package-owned-by-an-organization
           gh api --paginate --slurp \

--- a/.github/workflows/github-cache-eviction.yml
+++ b/.github/workflows/github-cache-eviction.yml
@@ -43,7 +43,7 @@ jobs:
             > versions.json
 
           jq --compact-output --raw-output --arg e "$eviction_time" \
-            '[.[][] | select(.modified_at < $e)]' \
+            '[.[][] | select(.updated_at < $e)]' \
             versions.json
             > evictions.json
 

--- a/.github/workflows/scheduled-cache-eviction.yml
+++ b/.github/workflows/scheduled-cache-eviction.yml
@@ -10,6 +10,6 @@ jobs:
     with:
       buildcache-package-org: ${{ github.repository_owner }}
       buildcache-package-name: build-ci-buildcache
-      eviction-threshold: 90
+      eviction-threshold-days: 90
     secrets:
       token: ${{ github.token }}

--- a/.github/workflows/scheduled-cache-eviction.yml
+++ b/.github/workflows/scheduled-cache-eviction.yml
@@ -1,0 +1,15 @@
+name: Scheduled Cache Eviction
+on:
+  schedule:
+    - cron: 30 2 3 * *
+jobs:
+  eviction:
+    permissions:
+      packages: write
+    uses: ./.github/workflows/github-cache-eviction.yml
+    with:
+      buildcache-package-org: ${{ github.repository_owner }}
+      buildcache-package-name: build-ci-buildcache
+      eviction-threshold: 90
+    secrets:
+      token: ${{ github.token }}


### PR DESCRIPTION
Closes #288

## Background

Currently, every package is pushed to the GitHub Spack Cache, and none are deleted. Eventually, we will hit our head on some limit from GitHub, so we should proactively delete entries that are stale. 

Unfortunately, we don't have any way to know when an image version (AKA a package) was last pulled, so the next best thing we have is to evict based on last modified time. 

## The PR

- **Create github-cache-eviction.yml reusable, for removing entries from a GitHub buildcache**
- **Also create scheduled-cache-eviction.yml that calls github-cache-eviction.yml**
- **Update README.md, reworked headings**

## Testing

Tested commands in sequence:

```sh
eviction_time=$(date --universal --date "-90 days" +%FT%TZ)  # 2025-12-27T00:49:21Z
gh api --paginate --slurp /orgs/access-nri/packages/container/build-ci-buildcache/versions > versions.json
cat versions.json  # ALL versions defined
# [[{"id":751523677,"name":"sha256:679ff5dff717cace63e5dcbc00d1ce22061eaba30ae6ced96230b0e6fa2a4a6c","url":"https://api.github.com/orgs/ACCESS-NRI/packages/container/build-ci-buildcache/versions/751523677","package_html_url":"https://github.com/orgs/ACCESS-NRI/packages/container/package/build-ci-buildcache","created_at":"2026-03-23T03:41:39Z","updated_at":"2026-03-23T03:41:39Z","description":"netcdf-fortran@=4.6.1~doc+pic+shared build_system=autotools platform=linux os=rocky8 target=x86_64","html_url":"https://github.com/orgs/ACCESS-NRI/packages/container/build-ci-buildcache/751523677","metadata":{"package_type":"container","container":{"tags":["netcdf-fortran-4.6.1-dbzypnglwn4bq6vwr2kikfpdcxsz5q45.spack"]}}}, ...]]
jq -cr --arg e "$eviction_time" '[.[][] | select(.updated_at < $e)]' versions.json > evictions.json
cat evictions.json  # All versions older than 90 days
# [{"id":611140504,"name":"sha256:c15af82553ae55c502e2953a9606542407a8a7ea14ee785fd469f5ccf67807ca","url":"https://api.github.com/orgs/ACCESS-NRI/packages/container/build-ci-buildcache/versions/611140504","package_html_url":"https://github.com/orgs/ACCESS-NRI/packages/container/package/build-ci-buildcache","created_at":"2025-12-15T03:37:13Z","updated_at":"2025-12-15T03:37:13Z","description":"netcdf-fortran@=4.5.2~doc+pic+shared build_system=autotools patches:=b050dbd platform=linux os=rocky8 target=x86_64","html_url":"https://github.com/orgs/ACCESS-NRI/packages/container/build-ci-buildcache/611140504","metadata":{"package_type":"container","container":{"tags":["netcdf-fortran-4.5.2-hqifenmxf2ggq4kqk26jtwbdqzxvu657.spack"]}}}, ...]
eviction_ids=$(jq -cr '[.[] | .id]' evictions.json)  # [751523677,611140504, ...]
# Testing just one...
gh api --method DELETE /orgs/access-nri/packages/container/build-ci-buildcache/versions/751523677
gh api /orgs/access-nri/packages/container/build-ci-buildcache/versions/751523677
# No longer exists!
```
