### PR TITLE
Enable spack before adding runner set buildcache back

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,6 +300,7 @@ jobs:
       - name: Spack - Enable Runner Set Buildcache
         if: inputs.run-self-hosted
         run: |
+          . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
           spack mirror add --scope=user --autopush --unsigned runner_set_buildcache /opt/runner_set_buildcache
           spack mirror list
 


### PR DESCRIPTION
See https://github.com/ACCESS-NRI/access-spack-packages/actions/runs/24382950802/job/71210288439

## Background

A regression introduced in https://github.com/ACCESS-NRI/build-ci/pull/292, in which I didn't enable spack before running the command.

## The PR

* Enable spack before running it to create the runner set mirror
