### PR TITLE
GitHub-Hosted Image Fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,7 +346,7 @@ jobs:
         if: inputs.spack-oci-buildcache-url != ''
         run: |
           . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
-          spack mirror add --scope=site \
+          spack mirror add --scope=user \
             --unsigned \
             --oci-username-variable OCI_USERNAME \
             --oci-password-variable OCI_PASSWORD \
@@ -384,7 +384,7 @@ jobs:
           spack env deactivate
           yq '.spack.specs[]' ${{ inputs.spack-compiler-manifest-path }} | while read compiler; do
             spack load $compiler
-            spack compiler find --scope=site
+            spack compiler find --scope=user
           done
           spack compiler list
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,6 +372,7 @@ jobs:
       - name: Manifest - Install Compilers Locally
         # Some compilers may not be available upstream, so we install them locally in a separate spack.yaml
         if: inputs.spack-compiler-manifest-path != ''
+        id: compilers
         env:
           # For pulling OCI buildcache
           OCI_USERNAME: ${{ secrets.spack-oci-buildcache-username || github.actor }}
@@ -387,6 +388,17 @@ jobs:
             spack compiler find --scope=user
           done
           spack compiler list
+
+      - name: Manifest - Push Local Compilers to Buildcache
+        env:
+          # For pulling and pushing OCI buildcache
+          # If secrets.GITHUB_TOKEN has permissions.packages:write, one would not have to specify secrets.spack-oci-buildcache-password
+          OCI_USERNAME: ${{ secrets.spack-oci-buildcache-username || github.actor }}
+          OCI_PASSWORD: ${{ secrets.spack-oci-buildcache-password || secrets.GITHUB_TOKEN }}
+        if: inputs.spack-oci-buildcache-url != '' && steps.compilers.outcome == 'success'
+        run: |
+          . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
+          spack -e local_compilers buildcache push --unsigned oci_buildcache
 
       - name: Manifest - Install jinja-cli
         run: python3 -m pip install jinja-cli==1.2.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,7 @@ jobs:
     name: Install and Test
     runs-on: ${{ inputs.run-self-hosted && fromJson('{"group":"build-ci"}') || 'ubuntu-latest' }}
     container:
-      image: ${{ inputs.run-self-hosted && 'ghcr.io/access-nri/build-ci-runner' || 'ghcr.io/access-nri/build-ci-upstream' }}${{ inputs.container-image-version }}
+      image: ghcr.io/access-nri/build-ci-runner${{ inputs.container-image-version }}
       volumes:
         # For self-hosted runners, mount the proper upstream and buildcache volumes from the kubernetes cluster
         # For GitHub-hosted runners, mount the dummy volume /dev/null to avoid errors or undefined behavior, eg. fromJson('[]')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,6 +266,13 @@ jobs:
           # The upload step later requires a non-relative path, hence the realpath
           echo "spack-env-dir=$(realpath $SPACK_ROOT/../runner/environments)" >> $GITHUB_OUTPUT
 
+      - name: Init - Disable upstream
+        if: ${{ ! inputs.run-self-hosted }}
+        # For GitHub-hosted versions of build-ci, we don't have an upstream, so we disable in our user scope
+        run: |
+          . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
+          echo "upstreams:: {}" > $(spack config --scope=user edit --print-file upstreams)
+
       - name: Update - spack-config version
         id: spack-config-update
         uses: access-nri/build-ci/.github/actions/git-checkout-updated-ref@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,9 +269,12 @@ jobs:
       - name: Init - Disable upstream
         if: ${{ ! inputs.run-self-hosted }}
         # For GitHub-hosted versions of build-ci, we don't have an upstream, so we disable in our user scope
+        # NOTE: In future may be able to be replaced by spack config --scope=user add upstreams::{}
         run: |
           . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
-          echo "upstreams:: {}" > $(spack config --scope=user edit --print-file upstreams)
+          upstream_location=$(spack config --scope=user edit upstreams --print-file)
+          mkdir -p $(dirname $upstream_location)
+          echo "upstreams:: {}" > $upstream_location
 
       - name: Update - spack-config version
         id: spack-config-update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,6 +379,7 @@ jobs:
         run: |
           . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
           spack env activate local_compilers --create --prompt --envfile ${{ inputs.spack-compiler-manifest-path }}
+          spack config blame mirrors
           spack --debug install --fail-fast --deprecated
           spack env deactivate
           yq '.spack.specs[]' ${{ inputs.spack-compiler-manifest-path }} | while read compiler; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,7 @@ jobs:
           # The upload step later requires a non-relative path, hence the realpath
           echo "spack-env-dir=$(realpath $SPACK_ROOT/../runner/environments)" >> $GITHUB_OUTPUT
 
-      - name: Init - Disable self-hosted runner features
+      - name: Init - Disable Self-Hosted Upstreams
         if: ${{ ! inputs.run-self-hosted }}
         # For GitHub-hosted versions of build-ci, we don't have an upstream, so we disable in our user scope
         # NOTE: In future may be able to be replaced by spack config --scope=user add upstreams::{}
@@ -278,10 +278,6 @@ jobs:
           mkdir -p $(dirname $upstream_location)
           echo "upstreams:: {}" > $upstream_location
           spack config blame upstreams
-
-          echo "--- Disable self-hosted runner buildcache"
-          spack mirror rm runner_set_buildcache
-          spack config blame mirrors
 
       - name: Update - spack-config version
         id: spack-config-update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,15 +266,22 @@ jobs:
           # The upload step later requires a non-relative path, hence the realpath
           echo "spack-env-dir=$(realpath $SPACK_ROOT/../runner/environments)" >> $GITHUB_OUTPUT
 
-      - name: Init - Disable upstream
+      - name: Init - Disable self-hosted runner features
         if: ${{ ! inputs.run-self-hosted }}
         # For GitHub-hosted versions of build-ci, we don't have an upstream, so we disable in our user scope
         # NOTE: In future may be able to be replaced by spack config --scope=user add upstreams::{}
         run: |
           . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
+
+          echo "--- Disable upstream ---"
           upstream_location=$(spack config --scope=user edit upstreams --print-file)
           mkdir -p $(dirname $upstream_location)
           echo "upstreams:: {}" > $upstream_location
+          spack config blame upstreams
+
+          echo "--- Disable self-hosted runner buildcache"
+          spack mirror rm runner_set_buildcache
+          spack config blame mirrors
 
       - name: Update - spack-config version
         id: spack-config-update
@@ -390,7 +397,7 @@ jobs:
         run: |
           . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
           spack env activate local_compilers --create --prompt --envfile ${{ inputs.spack-compiler-manifest-path }}
-          spack config blame mirrors
+
           spack --debug install --fail-fast --deprecated
           spack env deactivate
           yq '.spack.specs[]' ${{ inputs.spack-compiler-manifest-path }} | while read compiler; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,7 +398,7 @@ jobs:
         if: inputs.spack-oci-buildcache-url != '' && steps.compilers.outcome == 'success'
         run: |
           . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
-          spack -e local_compilers buildcache push --unsigned oci_buildcache
+          spack -e local_compilers buildcache push --unsigned --private oci_buildcache
 
       - name: Manifest - Install jinja-cli
         run: python3 -m pip install jinja-cli==1.2.2


### PR DESCRIPTION
Closes #268

## Background

The upstream image that we used to run solely for GitHub-hosted invocations of `build-ci` is too large for GitHub-hosted runners to cope with. 

Rather than slimming down the image, We will instead rely solely on a binary buildcache for the install. 

### Caveats

This is slower than self-hosted runners, and slower than using an `upstream` image as a base, as not having an upstream means the concretizer will not reuse upstream-installed packages, which means that cache misses are more likely. 

Some alternatives to do if MCRs are consistently missing the cache:

* Explicitly set `inputs.spack-ref`/`inputs.spack-config-ref`/`inputs.builtin-spack-packages-ref`/`inputs.access-spack-packages-ref` to a commit SHA. This means that the concretization decisions should not vary based on different repo versions - and therefore we will almost always have cache hits. 
* In the case of compilers defined in a manifest as part of `inputs.spack-compiler-manifest-path`, use the long hash of a compiler pushed to the buildcache for perfect reuse every time:
  ```yaml
  spack:
    specs:
    - /aorj2398u2rio2kr209r209ir20
    # ...
  ```
* The above can work for packages also, in the manifest defined in the `inputs.spack-manifest-path`. 

## The PR

* Run only the `build-ci-runner` image, regardless of `inputs.run-self-hosted`, as we can't use the `build-ci-upstream` as a base. 
* Disable the spack upstream if not `inputs.run-self-hosted`
* Push Compilers installed locally to a buildcache
* Update `--scope=site` to `--scope=user` in some places

## Testing

Tested in https://github.com/CABLE-LSM/CABLE/pull/654 - it takes slightly longer to reinstall compilers from the cache, but this is unavoidable. Furthermore, since there is no upstream that can be used to influence the concretization, there is more of a chance that the hashes will be different from what is in the buildcache. 

Example of both a perfect hit on the buildcache [for compiler and manifest](https://github.com/CABLE-LSM/CABLE/actions/runs/24433564801/job/71382850677#step:22:31), and [just the compiler](https://github.com/CABLE-LSM/CABLE/actions/runs/24433564801/job/71382850675#step:22:27). This should be alleviated somewhat while the buildcache fills up. 