### PR TITLE
Post-Build Testing

### DIFF
--- a/.github/actions/setup-instance/README.md
+++ b/.github/actions/setup-instance/README.md
@@ -1,0 +1,51 @@
+# Setup Container Instance
+
+Action that prepares a build-ci runner container instance for CI by exporting key environment variables, updating repositories to requested refs, and configuring Spack mirrors/upstreams where required.
+
+## Inputs
+
+| Name | Type | Description | Required | Default | Example |
+| ---- | ---- | ----------- | -------- | ------- | ------- |
+| `spack-ref` | `string` (git branch, tag or sha) | The git ref to checkout for the `spack` repository. | `true` | N/A | `"develop"` or `"v1.0.0"` or `"5a1cdc4e"` or `""` |
+| `spack-config-ref` | `string` (git branch, tag or sha) | The git ref to checkout for the `spack-config` repository. | `true` | N/A | `"main"` or `"v0.5.2"` or `"3f14e99"` or `""` |
+| `builtin-spack-packages-ref` | `string` (git branch, tag or sha) | The git ref to checkout for the builtin spack packages repository. | `true` | N/A | `"develop"` or `"release-1.2"` or `"a8b7c6d"` or `""` |
+| `access-spack-packages-ref` | `string` (git branch, tag or sha) | The git ref to checkout for the `access-spack-packages` repository. | `true` | N/A | `"main"` or `"v2026.04"` or `"9e72b1c"` or `""` |
+| `spack-oci-buildcache-url` | `string` (URL) | The OCI registry URL to add as a Spack buildcache mirror. Pass an empty string (`''`) to skip adding an OCI mirror. | `true` | N/A | `"ghcr.io/access-nri/spack-buildcache"` or `""` |
+| `run-self-hosted` | `string` (boolean) | Whether this instance is running on a self-hosted runner. Controls upstream disabling and runner-set buildcache setup. | `true` | N/A | `"true"` or `"false"` |
+
+## Outputs
+
+| Name | Type | Description | Example |
+| ---- | ---- | ----------- | ------- |
+| `SPACK_ROOT` | `string` (path) | The Spack instance root path exported from the container environment. | `"/opt/spack"` |
+| `INITIAL_SPACK_REPO_VERSION` | `string` | The initial Spack repository version before any updates. | `"releases/v1.0"` |
+| `spack-env-dir` | `string` (path) | Absolute path to the runner environments directory used for artifact collection. | `"/opt/runner/environments"` |
+| `spack-config-sha` | `string` (sha) | The git SHA checked out for the `spack-config` repository. | `"5a1cdc4e4617fcd6ba1cccf1cd0432b5631983be"` |
+| `spack-sha` | `string` (sha) | The git SHA checked out for the `spack` repository. | `"d4e2fb7636e9ef3a8ebcf0f36f7f076f605ed87c"` |
+| `builtin-spack-packages-sha` | `string` (sha) | The git SHA checked out for the builtin spack packages repository. | `"4319878c9a9714f938df8f9a58d4f79aece39b7b"` |
+| `access-spack-packages-sha` | `string` (sha) | The git SHA checked out for the `access-spack-packages` repository. | `"77f9026d7e18bd4a0f9524f4b8a1e6f3f2345c9a"` |
+
+## Examples
+
+### Simple
+
+```yaml
+# ...
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    container:
+      image: access-nri/build-ci-runner:rocky
+    steps:
+    - id: instance
+      uses: access-nri/build-ci/.github/actions/setup-instance@v3
+      with:
+        spack-ref: releases/v1.1
+        spack-config-ref: main
+        builtin-spack-packages-ref: develop
+        access-spack-packages-ref: api-v2
+        spack-oci-buildcache-url: oci://ghcr.io/ACCESS-NRI/build-ci-buildcache
+        run-self-hosted: false
+
+    - run: echo "Spack root is ${{ steps.instance.outputs.SPACK_ROOT }}"
+```

--- a/.github/actions/setup-instance/action.yml
+++ b/.github/actions/setup-instance/action.yml
@@ -88,14 +88,14 @@ runs:
 
   - name: Update - spack-config version
     id: spack-config-update
-    uses: access-nri/build-ci/.github/actions/git-checkout-updated-ref@v3
+    uses: ./build-ci/.github/actions/git-checkout-updated-ref
     with:
       repository-path: ${{ steps.env.outputs.SPACK_ROOT }}/../spack-config
       ref: ${{ inputs.spack-config-ref }}
 
   - name: Update - spack version
     id: spack-update
-    uses: access-nri/build-ci/.github/actions/git-checkout-updated-ref@v3
+    uses: ./build-ci/.github/actions/git-checkout-updated-ref
     with:
       repository-path: ${{ steps.env.outputs.SPACK_ROOT }}
       ref: ${{ inputs.spack-ref }}
@@ -143,7 +143,7 @@ runs:
 
   - name: Update - access-spack-package version
     id: access-spack-packages-update
-    uses: access-nri/build-ci/.github/actions/spack-checkout-updated-ref@v3
+    uses: ./build-ci/.github/actions/spack-checkout-updated-ref
     with:
       spack-packages-repository-name: access_spack_packages
       spack-packages-repository-path: ${{ steps.spack-packages-locations.outputs.access-spack-packages }}
@@ -152,7 +152,7 @@ runs:
 
   - name: Update - builtin spack-package version
     id: builtin-spack-packages-update
-    uses: access-nri/build-ci/.github/actions/spack-checkout-updated-ref@v3
+    uses: ./build-ci/.github/actions/spack-checkout-updated-ref
     with:
       spack-packages-repository-name: builtin
       spack-packages-repository-path: ${{ steps.spack-packages-locations.outputs.builtin }}

--- a/.github/actions/setup-instance/action.yml
+++ b/.github/actions/setup-instance/action.yml
@@ -68,11 +68,11 @@ runs:
     shell: bash
     if: ${{ ! inputs.run-self-hosted }}
     # For GitHub-hosted versions of build-ci, we don't have an upstream, so we disable in our user scope
-    # NOTE: In future may be able to be replaced by spack config --scope=user add upstreams::{}
+    # NOTE: In future may be able to be replaced by spack config --scope=access.nri.ci.user add upstreams::{}
     run: |
       . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
 
-      upstream_location=$(spack config --scope=user edit upstreams --print-file)
+      upstream_location=$(spack config --scope=access.nri.ci.user edit upstreams --print-file)
       mkdir -p $(dirname $upstream_location)
       echo "upstreams:: {}" > $upstream_location
       spack config blame upstreams
@@ -83,7 +83,7 @@ runs:
     run: |
       . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
 
-      spack mirror add --scope=user --autopush --unsigned runner_set_buildcache /opt/runner_set_buildcache
+      spack mirror add --scope=access.nri.ci.user --autopush --unsigned runner_set_buildcache /opt/runner_set_buildcache
       spack mirror list
 
   - name: Update - spack-config version
@@ -141,15 +141,6 @@ runs:
       echo "builtin=$(spack location --repo builtin)" >> $GITHUB_OUTPUT
       echo "access-spack-packages=$(spack location --repo access.nri)" >> $GITHUB_OUTPUT
 
-  - name: Update - builtin spack-package version
-    id: builtin-spack-packages-update
-    uses: access-nri/build-ci/.github/actions/spack-checkout-updated-ref@v3
-    with:
-      spack-packages-repository-name: builtin
-      spack-packages-repository-path: ${{ steps.spack-packages-locations.outputs.builtin }}
-      ref: ${{ inputs.builtin-spack-packages-ref || steps.get-default-builtin.outputs.ref }}
-      spack-instance-root-path: ${{ steps.env.outputs.SPACK_ROOT }}
-
   - name: Update - access-spack-package version
     id: access-spack-packages-update
     uses: access-nri/build-ci/.github/actions/spack-checkout-updated-ref@v3
@@ -159,12 +150,21 @@ runs:
       ref: ${{ inputs.access-spack-packages-ref }}
       spack-instance-root-path: ${{ steps.env.outputs.SPACK_ROOT }}
 
+  - name: Update - builtin spack-package version
+    id: builtin-spack-packages-update
+    uses: access-nri/build-ci/.github/actions/spack-checkout-updated-ref@v3
+    with:
+      spack-packages-repository-name: builtin
+      spack-packages-repository-path: ${{ steps.spack-packages-locations.outputs.builtin }}
+      ref: ${{ inputs.builtin-spack-packages-ref || steps.get-default-builtin.outputs.ref }}
+      spack-instance-root-path: ${{ steps.env.outputs.SPACK_ROOT }}
+
   - name: Spack - OCI Buildcache Init
     if: inputs.spack-oci-buildcache-url != ''
     shell: bash
     run: |
       . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
-      spack mirror add --scope=user \
+      spack mirror add --scope=access.nri.ci.user \
         --unsigned \
         --oci-username-variable OCI_USERNAME \
         --oci-password-variable OCI_PASSWORD \

--- a/.github/actions/setup-instance/action.yml
+++ b/.github/actions/setup-instance/action.yml
@@ -1,0 +1,172 @@
+name: Setup Container Instance
+description: Common action for getting a build-ci-runner containers repositories up to date and ready to run
+inputs:
+  spack-ref:
+    description: The git ref to checkout for the spack repository. Can be a branch, tag, or commit. If not provided, spack will not be updated and the version in the image will be used.
+    required: true
+  spack-config-ref:
+    description: The git ref to checkout for the spack-config repository. Can be a branch, tag, or commit. If not provided, spack-config will not be updated and the version in the image will be used.
+    required: true
+  builtin-spack-packages-ref:
+    description: The git ref to checkout for the builtin spack packages repository. Can be a branch, tag, or commit. If not provided, the ref specified in spack-config's repos.yaml will be used, or "develop" if not specified there either.
+    required: true
+  access-spack-packages-ref:
+    description: The git ref to checkout for the access spack packages repository. Can be a branch, tag, or commit. If not provided, access-spack-packages will not be updated and the version in the image will be used.
+    required: true
+  spack-oci-buildcache-url:
+    description: The URL of an OCI registry to use as a Spack buildcache. If not provided, no OCI registry will be added as a Spack mirror.
+    required: true
+  run-self-hosted:
+    description: Whether this instance is running on a self-hosted runner. Used to determine whether to disable upstreams and whether to enable the runner set buildcache.
+    required: true
+outputs:
+  # From env step
+  SPACK_ROOT:
+    value: ${{ steps.env.outputs.SPACK_ROOT }}
+    description: The SPACK_ROOT of the spack instance. This is used by future steps to source the spack environment and for path construction purposes.
+  INITIAL_SPACK_REPO_VERSION:
+    value: ${{ steps.env.outputs.INITIAL_SPACK_REPO_VERSION }}
+    description: The initial spack repository version before any updates. This is used to determine if the spack version in the image is compatible with build-ci.
+  spack-env-dir:
+    value: ${{ steps.env.outputs.spack-env-dir }}
+    description: The directory where spack environments are stored. This is used for artifact collection purposes in future steps.
+  # From *-update steps
+  spack-config-sha:
+    value: ${{ steps.spack-config-update.outputs.sha }}
+    description: The git sha that was checked out for the spack-config repository.
+  spack-sha:
+    value: ${{ steps.spack-update.outputs.sha }}
+    description: The git sha that was checked out for the spack repository.
+  builtin-spack-packages-sha:
+    value: ${{ steps.builtin-spack-packages-update.outputs.sha }}
+    description: The git sha that was checked out for the builtin spack packages repository.
+  access-spack-packages-sha:
+    value: ${{ steps.access-spack-packages-update.outputs.sha }}
+    description: The git sha that was checked out for the access spack packages repository.
+runs:
+  using: composite
+  steps:
+  - name: Init - Export environment variables into GitHub Actions format
+    shell: bash
+    # Environment variables inside containers are not accessible in the `env` context,
+    # a context which would be used in future conditional steps.
+    # This step exports important container environment variables as outputs.
+    # And yes, this loop echoes name-of-var=value-of-var!
+    id: env
+    run: |
+      for var in SPACK_ROOT INITIAL_SPACK_REPO_VERSION; do
+        echo "$var=${!var}" >> $GITHUB_OUTPUT
+      done
+
+      # The upload step later requires a non-relative path, hence the realpath
+      echo "spack-env-dir=$(realpath $SPACK_ROOT/../runner/environments)" >> $GITHUB_OUTPUT
+
+      # Initialize artifact content directory
+      mkdir -p ${{ env.artifact-content-dir }}
+
+  - name: Init - Disable Self-Hosted Upstreams
+    shell: bash
+    if: ${{ ! inputs.run-self-hosted }}
+    # For GitHub-hosted versions of build-ci, we don't have an upstream, so we disable in our user scope
+    # NOTE: In future may be able to be replaced by spack config --scope=user add upstreams::{}
+    run: |
+      . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
+
+      upstream_location=$(spack config --scope=user edit upstreams --print-file)
+      mkdir -p $(dirname $upstream_location)
+      echo "upstreams:: {}" > $upstream_location
+      spack config blame upstreams
+
+  - name: Init - Enable Runner Set Buildcache
+    if: inputs.run-self-hosted
+    shell: bash
+    run: |
+      . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
+
+      spack mirror add --scope=user --autopush --unsigned runner_set_buildcache /opt/runner_set_buildcache
+      spack mirror list
+
+  - name: Update - spack-config version
+    id: spack-config-update
+    uses: access-nri/build-ci/.github/actions/git-checkout-updated-ref@v3
+    with:
+      repository-path: ${{ steps.env.outputs.SPACK_ROOT }}/../spack-config
+      ref: ${{ inputs.spack-config-ref }}
+
+  - name: Update - spack version
+    id: spack-update
+    uses: access-nri/build-ci/.github/actions/git-checkout-updated-ref@v3
+    with:
+      repository-path: ${{ steps.env.outputs.SPACK_ROOT }}
+      ref: ${{ inputs.spack-ref }}
+
+  - name: Update - Validate non-updated spack
+    if: steps.spack-update.outputs.updated == 'false' && steps.spack-config-update.outputs.updated == 'false'
+    # We don't support spack < v1.0 in build-ci@v3, so we error out if the spack version is not updated and the version in the image is < v1.0
+    shell: bash
+    run: |
+      if [[ "${{ steps.env.outputs.INITIAL_SPACK_REPO_VERSION }}" == "releases/v0"* ]]; then
+        echo "::error::spack branch ${{ steps.env.outputs.INITIAL_SPACK_REPO_VERSION }} is not a v1.x branch, and build-ci@v3 only supports spack >= v1.0. Use build-ci@v2 for spack < v1.0"
+        exit 2
+      fi
+
+  - name: Spack - Initial Enable
+    shell: bash
+    run: |
+      . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
+      echo "----- Compilers -----"
+      spack compiler list
+      echo "----- Packages -----"
+      spack find
+
+  - name: Spack - Get builtin ref from spack-config
+    if: inputs.builtin-spack-packages-ref == ''
+    id: get-default-builtin
+    shell: bash
+    # If inputs.builtin-spack-packages-ref is not provided, get the builtin-spack-packages-ref
+    # from spack-config's repos.yaml or use "develop" (the default branch) if not specified there either.
+    run: |
+      . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
+      # Accept both the overridden .builtin: and regular .builtin key. See ACCESS-NRI/spack-config#105 for more info.
+      ref=$(spack config get repos | yq '.repos | .builtin // ."builtin:" | .branch // .tag // .commit // "develop"')
+      echo "Default builtin-spack-packages-ref is $ref"
+      echo "ref=$ref" >> $GITHUB_OUTPUT
+
+  - name: Spack - Get spack-packages repo locations
+    id: spack-packages-locations
+    shell: bash
+    run: |
+      . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
+
+      echo "builtin=$(spack location --repo builtin)" >> $GITHUB_OUTPUT
+      echo "access-spack-packages=$(spack location --repo access.nri)" >> $GITHUB_OUTPUT
+
+  - name: Update - builtin spack-package version
+    id: builtin-spack-packages-update
+    uses: access-nri/build-ci/.github/actions/spack-checkout-updated-ref@v3
+    with:
+      spack-packages-repository-name: builtin
+      spack-packages-repository-path: ${{ steps.spack-packages-locations.outputs.builtin }}
+      ref: ${{ inputs.builtin-spack-packages-ref || steps.get-default-builtin.outputs.ref }}
+      spack-instance-root-path: ${{ steps.env.outputs.SPACK_ROOT }}
+
+  - name: Update - access-spack-package version
+    id: access-spack-packages-update
+    uses: access-nri/build-ci/.github/actions/spack-checkout-updated-ref@v3
+    with:
+      spack-packages-repository-name: access_spack_packages
+      spack-packages-repository-path: ${{ steps.spack-packages-locations.outputs.access-spack-packages }}
+      ref: ${{ inputs.access-spack-packages-ref }}
+      spack-instance-root-path: ${{ steps.env.outputs.SPACK_ROOT }}
+
+  - name: Spack - OCI Buildcache Init
+    if: inputs.spack-oci-buildcache-url != ''
+    shell: bash
+    run: |
+      . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
+      spack mirror add --scope=user \
+        --unsigned \
+        --oci-username-variable OCI_USERNAME \
+        --oci-password-variable OCI_PASSWORD \
+        oci_buildcache ${{ inputs.spack-oci-buildcache-url }}
+      spack mirror list

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -28,7 +28,8 @@ This workflow handles building and running short CI tests on a given spack manif
 | `container-image-version` | `string` (Docker version ref) | The version of the container image to use for the runner. Can be either a `:TAG` or a `@sha256:SHA`. | `false` | `":rocky"` | `':8.9'` (tag), `'@sha256:1234...'` (SHA) |
 | `spack-oci-buildcache-url` | `string` (OCI URL) | The URL to an oci-backed buildcache, available in spack >= v1.0. OCI-backed buildcaches are the only option for GitHub-hosted CI, and can be used as a backup for self-hosted CI's runner buildcache | `false` | N/A | `"oci://ghcr.io/ACCESS-NRI/build-ci-buildcache"`, `"oci://ghcr.io/ORG/IMAGE"` |
 | `run-self-hosted` | `boolean` | Whether to run the job on a self-hosted runner. For security, workflow runs will hang if this is `true` but it is not using a valid `v*` branch or tag for the workflow ref | `false` | `true` | `true`, `false` |
-| `enable-pytest` | `boolean` | Whether to enable post-build testing of the manifest. All visible pytests under inputs.spack-manifest-repository will be run | `false` | `false` | `true`, `false` |
+| `enable-pytest` | `boolean` | Whether to enable post-build testing of the manifest | `false` | `false` | `true`, `false` |
+| `pytest-search-path` | `string` | The path to search for pytest tests, relative to the caller repository root. Note that hidden directories are not searched in this default. | `false` | `.` | `.github/build/tests`, `tests/` |
 
 #### Secrets
 
@@ -253,7 +254,7 @@ jobs:
 
 ##### Post-Build Testing via Pytest
 
-Using `inputs.enable-pytest` and having tests discoverable by `pytest` in the MCR, one can run post-build testing of the given manifest. We use `pytest` as a sort of testing meta-framework - so we have a central interface for testing many different model components with many different testing frameworks.
+Using `inputs.enable-pytest` and having tests discoverable by `pytest` under `inputs.pytest-search-path` in the MCR, one can run post-build testing of the given manifest. We use `pytest` as a sort of testing meta-framework - so we have a central interface for testing many different model components with many different testing frameworks.
 
 In order to add args to the `pytest` invocation, one can add a Reserved Definition (a section used by spack for reusable package definitions, etc, but prepended with a `_` to note that it is unused in the manifest), like so:
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -28,13 +28,7 @@ This workflow handles building and running short CI tests on a given spack manif
 | `container-image-version` | `string` (Docker version ref) | The version of the container image to use for the runner. Can be either a `:TAG` or a `@sha256:SHA`. | `false` | `":rocky"` | `':8.9'` (tag), `'@sha256:1234...'` (SHA) |
 | `spack-oci-buildcache-url` | `string` (OCI URL) | The URL to an oci-backed buildcache, available in spack >= v1.0. OCI-backed buildcaches are the only option for GitHub-hosted CI, and can be used as a backup for self-hosted CI's runner buildcache | `false` | N/A | `"oci://ghcr.io/ACCESS-NRI/build-ci-buildcache"`, `"oci://ghcr.io/ORG/IMAGE"` |
 | `run-self-hosted` | `boolean` | Whether to run the job on a self-hosted runner. For security, workflow runs will hang if this is `true` but it is not using a valid `v*` branch or tag for the workflow ref | `false` | `true` | `true`, `false` |
-
-##### Future Inputs
-
-| Name | Type | Description | Required | Default | Example |
-| ---- | ---- | ----------- | -------- | ------- | ------- |
-| `pytest-test-directory-path` | `string` (Directory path relative to component repository root) | Directory path in the caller model component repository that contains pytests to run against the built manifests | `false` | N/A | `".github/build/tests/"` |
-| `pytest-test-markers` | `string` (Pytest-style markers) | A string of pytest markers to use to filter tests in the caller model component repository | `false` | `""` (runs all tests) | `"not slow and not mpi"` |
+| `enable-pytest` | `boolean` | Whether to enable post-build testing of the manifest. All visible pytests under inputs.spack-manifest-repository will be run | `false` | `false` | `true`, `false` |
 
 #### Secrets
 
@@ -59,12 +53,6 @@ This workflow handles building and running short CI tests on a given spack manif
 | `container-id` | `string` | The ID of the container where the spack packages have been installed | `"ohfn2ofy2h2uyfg2uyg3uyg3uh"` |
 | `artifact-pattern` | `string` (glob) | Wildcard pattern to match all artifacts across a matrix job | `'output-*'` |
 | `artifact-url` | `string` (URL) | The URL of the artifact | `"https://github.com/ACCESS-NRI/MOM5/actions/runs/15890554355/artifacts/3406449135"` |
-
-##### Future Outputs
-
-| Name | Type | Description | Example |
-| ---- | ---- | ----------- | ------- |
-| `test-artifact-url` | `string` (URL) | The URL of the pytest result artifact | `"https://github.com/ACCESS-NRI/MOM5/actions/runs/15890554355/artifacts/3406449136"` |
 
 #### Examples
 
@@ -261,6 +249,19 @@ jobs:
           echo "For job with container id: $(jq '.container_id' $f)"
           jq '.spec_concretization_graph' $f
         done
+```
+
+##### Post-Build Testing via Pytest
+
+Using `inputs.enable-pytest` and having tests discoverable by `pytest` in the MCR, one can run post-build testing of the given manifest. We use `pytest` as a sort of testing meta-framework - so we have a central interface for testing many different model components with many different testing frameworks.
+
+In order to add args to the `pytest` invocation, one can add a Reserved Definition (a section used by spack for reusable package definitions, etc, but prepended with a `_` to note that it is unused in the manifest), like so:
+
+```yaml
+spack:
+  definitions:
+  - _pytest-args: ['-m marker1 and not marker2', '--verbosity=1']
+  # ...
 ```
 
 ## Other Workflows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,7 +272,7 @@ jobs:
 
       - name: Setup - Setup and Update Instance
         id: setup
-        uses: build-ci/.github/actions/setup-instance
+        uses: ./build-ci/.github/actions/setup-instance
         with:
           spack-ref: ${{ inputs.spack-ref }}
           spack-config-ref: ${{ inputs.spack-config-ref }}
@@ -299,7 +299,6 @@ jobs:
           ref: ${{ steps.init.outputs.spack-manifest-repository-ref }}
           # Only checkout the manifests, rather than the entire repository
           path: manifest
-          sparse-checkout-cone-mode: false
           sparse-checkout: |-
             ${{ inputs.spack-manifest-path }}
             ${{ inputs.spack-manifest-data-path }}
@@ -540,7 +539,7 @@ jobs:
 
       - name: Setup - Setup and Update Instance
         id: setup
-        uses: build-ci/.github/actions/setup-instance
+        uses: ./build-ci/.github/actions/setup-instance
         with:
           spack-ref: ${{ inputs.spack-ref }}
           spack-config-ref: ${{ inputs.spack-config-ref }}
@@ -551,7 +550,7 @@ jobs:
 
       - name: Manifest - Checkout Caller ${{ github.repository }}
         id: checkout-caller
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # The default ref is the merge commit for pull requests, which isn't able to be checked out locally
           # (and is therefore useless outside of the workflow run), so we get the PR head instead. See https://github.com/orgs/community/discussions/26325
@@ -561,7 +560,7 @@ jobs:
 
       - name: Manifest - Checkout Manifest From ${{ inputs.spack-manifest-repository }}
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ inputs.spack-manifest-repository }}
           ref: ${{ needs.spack-install.outputs.spack-manifest-repository-sha }}
@@ -569,9 +568,7 @@ jobs:
           path: manifest
           sparse-checkout-cone-mode: false
           sparse-checkout: |-
-            ${{ inputs.spack-manifest-path }}
-            ${{ inputs.spack-manifest-data-path }}
-            ${{ inputs.spack-compiler-manifest-path }}
+            ${{ inputs.pytest-search-path }}
           # Similarly to the spack install command below, we need to be able to checkout the spack-manifest-repository (which may be private)
           token: ${{ secrets.spack-install-command-pat || github.token }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,11 +131,6 @@ on:
         description: |
           Whether to enable post-build testing of the manifest.
           All visible pytests under inputs.spack-manifest-repository will be run.
-      pytest-args:
-        type: string
-        required: false
-        description: |
-          A list of pytest flags to affect the invocation of pytest. For example, addition of markers with '-m "marker_one and marker_two"'
     secrets:
       spack-install-command-pat:
         required: false
@@ -614,6 +609,14 @@ jobs:
       - name: Test - Install pytest
         run: python3 -m pip install pytest pytest-json-report
 
+      - name: Test - Read Potential Pytest Args From Reserved Definitions
+        id: reserved-defs
+        # Accepts _pytest-args arrays of the form: ['-m marker -k MyClass'] or ['-m marker', '-k MyClass']
+        run: |
+          args=$(yq '.spack.definitions[]._pytest-args // [] | join(" ")' ${{ env.artifact-content-dir }}/spack.yaml)
+          echo "Pytest args extracted from reserved definitions: $args"
+          echo "args=$args" >> $GITHUB_OUTPUT
+
       - name: Test - Pytest
         id: test
         run: |
@@ -622,7 +625,7 @@ jobs:
 
           . ${{ steps.setup.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
           spack env activate default
-          pytest ${{ inputs.pytest-args }} --json-report --json-report-file=$report_path
+          pytest ${{ steps.reserved-defs.outputs.args }} --json-report --json-report-file=$report_path
 
       - name: Test - Results
         id: results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -610,6 +610,7 @@ jobs:
           spack --debug install --fail-fast --deprecated --use-cache
 
       - name: Test - Install pytest
+        working-directory: manifest
         run: |
           python3 -m venv .ci-venv
           . .ci-venv/bin/activate
@@ -625,6 +626,7 @@ jobs:
 
       - name: Test - Pytest
         id: test
+        working-directory: manifest
         run: |
           json_report_path=${{ env.artifact-content-dir }}/pytest_report.json
           xml_report_path=${{ env.artifact-content-dir }}/pytest_report.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -624,8 +624,7 @@ jobs:
       - spack-install
     if: inputs.enable-pytest
     container:
-      # FIXME: This probably will be changed once there is a update to use only build-ci-runner
-      image: ${{ inputs.run-self-hosted && 'ghcr.io/access-nri/build-ci-runner' || 'ghcr.io/access-nri/build-ci-upstream' }}${{ inputs.container-image-version }}
+      image: ghcr.io/access-nri/build-ci-runner${{ inputs.container-image-version }}
       volumes:
         # For self-hosted runners, mount the proper upstream and buildcache volumes from the kubernetes cluster
         # For GitHub-hosted runners, mount the dummy volume /dev/null to avoid errors or undefined behavior, eg. fromJson('[]')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -611,7 +611,7 @@ jobs:
 
       - name: Test - Install pytest
         run: |
-          /usr/bin/python3.9 -m venv .ci-venv
+          python3 -m venv .ci-venv
           . .ci-venv/bin/activate
           pip install pytest pytest-json-report
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -616,23 +616,22 @@ jobs:
 
       - name: Test - Pytest
         id: test
-        env:
-          pytest-report-path: ${{ env.artifact-content-dir }}/pytest_report.json
         run: |
+          report_path=${{ env.artifact-content-dir }}/pytest_report.json
+          echo "report-path=$report_path" >> $GITHUB_OUTPUT
+
           . ${{ steps.setup.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
           spack env activate default
-          pytest ${{ inputs.pytest-args }} --json-report --json-report-file=${{ env.pytest-report-path }}
+          pytest ${{ inputs.pytest-args }} --json-report --json-report-file=$report_path
 
-          jq --raw-output '.summary' ${{ env.pytest-report-path }}
-          jq --raw-output '.summary.passed // 0' ${{ env.pytest-report-path }}
-          jq --raw-output '.summary.failed // 0' ${{ env.pytest-report-path }}
-          jq --raw-output '.summary.error // 0' ${{ env.pytest-report-path }}
-          jq --raw-output '.summary.total // 0' ${{ env.pytest-report-path }}
-
-          echo "passed=$(jq --raw-output '.summary.passed // 0' ${{ env.pytest-report-path }})" >> $GITHUB_OUTPUT
-          echo "failed=$(jq --raw-output '.summary.failed // 0' ${{ env.pytest-report-path }})" >> $GITHUB_OUTPUT
-          echo "error=$(jq --raw-output '.summary.error // 0' ${{ env.pytest-report-path }})" >> $GITHUB_OUTPUT
-          echo "total=$(jq --raw-output '.summary.total // 0' ${{ env.pytest-report-path }})" >> $GITHUB_OUTPUT
+      - name: Test - Results
+        id: results
+        if: always() && steps.test.outcome != 'skipped'
+        run: |
+          echo "passed=$(jq --raw-output '.summary.passed // 0' ${{ steps.test.outputs.report-path }})" >> $GITHUB_OUTPUT
+          echo "failed=$(jq --raw-output '.summary.failed // 0' ${{ steps.test.outputs.report-path }})" >> $GITHUB_OUTPUT
+          echo "error=$(jq --raw-output '.summary.error // 0' ${{ steps.test.outputs.report-path }})" >> $GITHUB_OUTPUT
+          echo "total=$(jq --raw-output '.summary.total // 0' ${{ steps.test.outputs.report-path }})" >> $GITHUB_OUTPUT
 
       - name: Outputs - Consolidate Job Outputs
         if: always() && steps.test.outcome != 'skipped'
@@ -641,10 +640,10 @@ jobs:
             --slurpfile outputs ${{ env.artifact-content-dir }}/job_outputs.json \
             '$outputs + {
               "test_build_result" : "${{ steps.test.outcome }}",
-              "tests_passed": ${{ steps.test.outputs.passed }},
-              "tests_failed": ${{ steps.test.outputs.failed }},
-              "tests_error": ${{ steps.test.outputs.error }},
-              "tests_total": ${{ steps.test.outputs.total }}
+              "tests_passed": ${{ steps.results.outputs.passed }},
+              "tests_failed": ${{ steps.results.outputs.failed }},
+              "tests_error": ${{ steps.results.outputs.error }},
+              "tests_total": ${{ steps.results.outputs.total }}
             }' \
             ${{ env.artifact-content-dir }}/job_outputs.json.tmp
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,13 @@ on:
         description: |
           The path to search for pytest tests, relative to the caller repository root.
           Note that hidden directories are not searched in this default.
-          For example: .github/build/tests.
+          For example: .github/build-ci/tests.
+      pytest-requirements-path:
+        type: string
+        required: false
+        description: |
+          The path to an optional requirements.txt to install pre-pytest, relative to the caller repository root.
+          For example: .github/build-ci/tests/requirements.txt
     secrets:
       spack-install-command-pat:
         required: false
@@ -611,10 +617,20 @@ jobs:
 
       - name: Test - Install pytest
         working-directory: manifest
+        env:
+          PYTEST_VERSION: 9.1.1
+          PYTEST_JSON_REPORT_VERSION: 1.5.0
         run: |
           python3 -m venv .ci-venv
           . .ci-venv/bin/activate
-          pip install pytest pytest-json-report
+          pip install pytest==${{ env.PYTEST_VERSION }} pytest-json-report==${{ env.PYTEST_JSON_REPORT_VERSION }}
+
+      - name: Test - Install Optional Requirements
+        if: inputs.pytest-requirements-path != ''
+        working-directory: manifest
+        run: |
+          . .ci-venv/bin/activate
+          pip install -r ${{ inputs.pytest-requirements-path }}
 
       - name: Test - Read Potential Pytest Args From Reserved Definitions
         id: reserved-defs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -504,7 +504,7 @@ jobs:
       - name: Outputs - Upload
         if: always() && (steps.install.conclusion == 'failure' || steps.install.conclusion == 'success')
         id: upload
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.init.outputs.artifact-name }}
           path: ${{ env.artifact-content-dir }}
@@ -574,7 +574,7 @@ jobs:
 
       - name: Download Install Artifact
         id: download-install-artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: ${{ needs.spack-install.outputs.artifact-name }}
           path: ${{ env.artifact-content-dir }}
@@ -681,7 +681,7 @@ jobs:
       - name: Outputs - Upload
         if: always()
         id: upload
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ needs.spack-install.outputs.artifact-name }}
           path: ${{ env.artifact-content-dir }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -613,14 +613,11 @@ jobs:
           spack env activate default --create --prompt --envfile ${{ env.artifact-content-dir }}/spack.lock
           spack --debug install --fail-fast --deprecated --use-cache
 
-      - name: Test - Install Python
-        uses: actions/setup-python@v6.2.0
-        with:
-          cache: pip
-          python-version: 3.11
-
       - name: Test - Install pytest
-        run: python3 -m pip install pytest pytest-json-report
+        run: |
+          /usr/bin/python3.9 -m venv .ci-venv
+          . .ci-venv/bin/activate
+          pip install pytest pytest-json-report
 
       - name: Test - Read Potential Pytest Args From Reserved Definitions
         id: reserved-defs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,10 +216,10 @@ jobs:
       # Job outputs outputted as workflow output
       spec-concretization-graph: ${{ steps.install.outputs.spec }}
       spack-manifest-repository-sha: ${{ steps.checkout.outputs.commit }}
-      spack-sha: ${{ steps.spack-update.outputs.sha }}
-      spack-config-sha: ${{ steps.spack-config-update.outputs.sha }}
-      builtin-spack-packages-sha: ${{ steps.builtin-spack-packages-update.outputs.sha }}
-      access-spack-packages-sha: ${{ steps.access-spack-packages-update.outputs.sha }}
+      spack-sha: ${{ steps.setup.outputs.spack-sha }}
+      spack-config-sha: ${{ steps.setup.outputs.spack-config-sha }}
+      builtin-spack-packages-sha: ${{ steps.setup.outputs.builtin-spack-packages-sha }}
+      access-spack-packages-sha: ${{ steps.setup.outputs.access-spack-packages-sha }}
       caller-sha: ${{ steps.checkout-caller.outputs.commit }}
       artifact-pattern: ${{ steps.init.outputs.artifact-pattern }}
       artifact-url: ${{ steps.upload.outputs.artifact-url }}
@@ -237,7 +237,7 @@ jobs:
           ref: ${{ job.workflow_sha }}
           path: build-ci
 
-      - name: Init - Initalize dynamic vars
+      - name: Init - Initalize workflow vars
         id: init
         # GitHub Actions doesn't allow expressions in the on.workflow_call.inputs.*.default section, so we need to define them here
         # Furthermore, some outputs depend on the container being started, so we define them here as well
@@ -270,122 +270,16 @@ jobs:
           echo "container-id=$container_id" >> $GITHUB_OUTPUT
           echo "short-container-id=$short_container_id" >> $GITHUB_OUTPUT
 
-          # Initialize artifact content directory
-          mkdir -p ${{ env.artifact-content-dir }}
-
-      - name: Init - Export environment variables into GitHub Actions format
-        # Environment variables inside containers are not accessible in the `env` context,
-        # a context which would be used in future conditional steps.
-        # This step exports important container environment variables as outputs.
-        # And yes, this loop echoes name-of-var=value-of-var!
-        id: env
-        run: |
-          for var in SPACK_ROOT INITIAL_SPACK_REPO_VERSION; do
-            echo "$var=${!var}" >> $GITHUB_OUTPUT
-          done
-
-          # The upload step later requires a non-relative path, hence the realpath
-          echo "spack-env-dir=$(realpath $SPACK_ROOT/../runner/environments)" >> $GITHUB_OUTPUT
-
-      - name: Init - Disable Self-Hosted Upstreams
-        if: ${{ ! inputs.run-self-hosted }}
-        # For GitHub-hosted versions of build-ci, we don't have an upstream, so we disable in our user scope
-        # NOTE: In future may be able to be replaced by spack config --scope=access.nri.ci.user add upstreams::{}
-        run: |
-          . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
-
-          echo "--- Disable upstream ---"
-          upstream_location=$(spack config --scope=access.nri.ci.user edit upstreams --print-file)
-          mkdir -p $(dirname $upstream_location)
-          echo "upstreams:: {}" > $upstream_location
-          spack config blame upstreams
-
-      - name: Update - spack-config version
-        id: spack-config-update
-        uses: ./build-ci/.github/actions/git-checkout-updated-ref
+      - name: Setup - Setup and Update Instance
+        id: setup
+        uses: build-ci/.github/actions/setup-instance
         with:
-          repository-path: ${{ steps.env.outputs.SPACK_ROOT }}/../spack-config
-          ref: ${{ inputs.spack-config-ref }}
-
-      - name: Update - spack version
-        id: spack-update
-        uses: ./build-ci/.github/actions/git-checkout-updated-ref
-        with:
-          repository-path: ${{ steps.env.outputs.SPACK_ROOT }}
-          ref: ${{ inputs.spack-ref }}
-
-      - name: Update - Validate non-updated spack
-        if: steps.spack-update.outputs.updated == 'false' && steps.spack-config-update.outputs.updated == 'false'
-        # We don't support spack < v1.0 in build-ci@v3, so we error out if the spack version is not updated and the version in the image is < v1.0
-        run: |
-          if [[ "${{ steps.env.outputs.INITIAL_SPACK_REPO_VERSION }}" == "releases/v0"* ]]; then
-            echo "::error::spack branch ${{ steps.env.outputs.INITIAL_SPACK_REPO_VERSION }} is not a v1.x branch, and build-ci@v3 only supports spack >= v1.0. Use build-ci@v2 for spack < v1.0"
-            exit 2
-          fi
-
-      - name: Spack - Initial Enable
-        run: |
-          . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
-          echo "----- Compilers -----"
-          spack compiler list
-          echo "----- Packages -----"
-          spack find
-
-      - name: Spack - Enable Runner Set Buildcache
-        if: inputs.run-self-hosted
-        run: |
-          . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
-          spack mirror add --scope=access.nri.ci.user --autopush --unsigned runner_set_buildcache /opt/runner_set_buildcache
-          spack mirror list
-
-      - name: Spack - Get builtin ref from spack-config
-        if: inputs.builtin-spack-packages-ref == ''
-        id: get-default-builtin
-        # If inputs.builtin-spack-packages-ref is not provided, get the builtin-spack-packages-ref
-        # from spack-config's repos.yaml or use "develop" (the default branch) if not specified there either.
-        run: |
-          . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
-          # Accept both the overridden .builtin: and regular .builtin key. See ACCESS-NRI/spack-config#105 for more info.
-          ref=$(spack config get repos | yq '.repos | .builtin // ."builtin:" | .branch // .tag // .commit // "develop"')
-          echo "Default builtin-spack-packages-ref is $ref"
-          echo "ref=$ref" >> $GITHUB_OUTPUT
-
-      - name: Spack - Get spack-packages repo locations
-        id: spack-packages-locations
-        run: |
-          . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
-
-          echo "builtin=$(spack location --repo builtin)" >> $GITHUB_OUTPUT
-          echo "access-spack-packages=$(spack location --repo access.nri)" >> $GITHUB_OUTPUT
-
-      - name: Update - access-spack-package version
-        id: access-spack-packages-update
-        uses: ./build-ci/.github/actions/spack-checkout-updated-ref
-        with:
-          spack-packages-repository-name: access_spack_packages
-          spack-packages-repository-path: ${{ steps.spack-packages-locations.outputs.access-spack-packages }}
-          ref: ${{ inputs.access-spack-packages-ref }}
-          spack-instance-root-path: ${{ steps.env.outputs.SPACK_ROOT }}
-
-      - name: Update - builtin spack-package version
-        id: builtin-spack-packages-update
-        uses: ./build-ci/.github/actions/spack-checkout-updated-ref
-        with:
-          spack-packages-repository-name: builtin
-          spack-packages-repository-path: ${{ steps.spack-packages-locations.outputs.builtin }}
-          ref: ${{ inputs.builtin-spack-packages-ref || steps.get-default-builtin.outputs.ref }}
-          spack-instance-root-path: ${{ steps.env.outputs.SPACK_ROOT }}
-
-      - name: Spack - OCI Buildcache Init
-        if: inputs.spack-oci-buildcache-url != ''
-        run: |
-          . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
-          spack mirror add --scope=access.nri.ci.user \
-            --unsigned \
-            --oci-username-variable OCI_USERNAME \
-            --oci-password-variable OCI_PASSWORD \
-            oci_buildcache ${{ inputs.spack-oci-buildcache-url }}
-          spack mirror list
+          spack-ref: ${{ inputs.spack-ref }}
+          spack-config-ref: ${{ inputs.spack-config-ref }}
+          builtin-spack-packages-ref: ${{ inputs.builtin-spack-packages-ref }}
+          access-spack-packages-ref: ${{ inputs.access-spack-packages-ref }}
+          spack-oci-buildcache-url: ${{ inputs.spack-oci-buildcache-url }}
+          run-self-hosted: ${{ inputs.run-self-hosted }}
 
       - name: Manifest - Checkout Caller ${{ github.repository }}
         id: checkout-caller
@@ -402,7 +296,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: ${{ inputs.spack-manifest-repository }}
-          ref: ${{ steps.init.outputs.spack-manifest-repository-ref }}
+          ref: ${{ steps.setup.outputs.spack-manifest-repository-ref }}
           # Only checkout the manifests, rather than the entire repository
           path: manifest
           sparse-checkout-cone-mode: false
@@ -429,7 +323,7 @@ jobs:
           OCI_USERNAME: ${{ secrets.spack-oci-buildcache-username || github.actor }}
           OCI_PASSWORD: ${{ secrets.spack-oci-buildcache-password || secrets.GITHUB_TOKEN }}
         run: |
-          . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
+          . ${{ steps.setup.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
           spack env activate local_compilers --create --prompt --envfile ${{ inputs.spack-compiler-manifest-path }}
 
           spack --debug install --fail-fast --deprecated
@@ -445,7 +339,7 @@ jobs:
           OCI_PASSWORD: ${{ secrets.spack-oci-buildcache-password || secrets.GITHUB_TOKEN }}
         if: inputs.spack-oci-buildcache-url != '' && steps.compilers.outcome == 'success'
         run: |
-          . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
+          . ${{ steps.setup.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
           spack -e local_compilers buildcache push --unsigned --private oci_buildcache
 
       - name: Manifest - Install jinja-cli
@@ -485,7 +379,7 @@ jobs:
           GIT_CONFIG_KEY_0: url.https://oauth2:${{ secrets.spack-install-command-pat || secrets.GITHUB_TOKEN }}@github.com/.insteadOf
           GIT_CONFIG_VALUE_0: https://github.com/
         run: |
-          . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
+          . ${{ steps.setup.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
           spack env create default ${{ steps.jinja-templated.outputs.spack-manifest-path }}
           spack env activate
 
@@ -510,7 +404,7 @@ jobs:
           OCI_PASSWORD: ${{ secrets.spack-oci-buildcache-password || secrets.GITHUB_TOKEN }}
         if: inputs.spack-oci-buildcache-url != ''
         run: |
-          . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
+          . ${{ steps.setup.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
           spack -e default buildcache push --unsigned --only=dependencies oci_buildcache
 
       - name: Tmate - Create session
@@ -538,25 +432,25 @@ jobs:
         continue-on-error: true
         run: |
           # Consolidate Manifests
-          if compgen -G "${{ steps.env.outputs.spack-env-dir }}/default/spack.*" > /dev/null; then
-            cp -v ${{ steps.env.outputs.spack-env-dir }}/default/spack.* ${{ env.artifact-content-dir }}
+          if compgen -G "${{ steps.setup.outputs.spack-env-dir }}/default/spack.*" > /dev/null; then
+            cp -v ${{ steps.setup.outputs.spack-env-dir }}/default/spack.* ${{ env.artifact-content-dir }}
           fi
 
-          if compgen -G "${{ steps.env.outputs.spack-env-dir }}/local_compilers/spack.*" > /dev/null; then
+          if compgen -G "${{ steps.setup.outputs.spack-env-dir }}/local_compilers/spack.*" > /dev/null; then
             mkdir -p ${{ env.artifact-content-dir }}/local_compilers
-            cp -v ${{ steps.env.outputs.spack-env-dir }}/local_compilers/spack.* ${{ env.artifact-content-dir }}/local_compilers
+            cp -v ${{ steps.setup.outputs.spack-env-dir }}/local_compilers/spack.* ${{ env.artifact-content-dir }}/local_compilers
           fi
 
           # Consolidate Logs
-          . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
+          . ${{ steps.setup.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
 
-          if [ ! -f ${{ steps.env.outputs.spack-env-dir }}/default/spack.lock ]; then
+          if [ ! -f ${{ steps.setup.outputs.spack-env-dir }}/default/spack.lock ]; then
             echo "Spack lock file not found, skipping log creation."
             exit 0
           fi
 
           # Get all the top-level hashes from the manifest
-          hashes="$(jq --raw-output '.roots[].hash' ${{ steps.env.outputs.spack-env-dir }}/default/spack.lock)"
+          hashes="$(jq --raw-output '.roots[].hash' ${{ steps.setup.outputs.spack-env-dir }}/default/spack.lock)"
           echo "Found top-level hashes:"
           echo "$hashes"
 
@@ -580,7 +474,7 @@ jobs:
           '{
             "spack_manifest_path": "${{ inputs.spack-manifest-path }}",
             "spack_manifest_repository": "${{ inputs.spack-manifest-repository }}",
-            "spack_manifest_repository_ref": "${{ steps.init.outputs.spack-manifest-repository-ref }}",
+            "spack_manifest_repository_ref": "${{ steps.setup.outputs.spack-manifest-repository-ref }}",
             "spack_manifest_data_path": "${{ inputs.spack-manifest-data-path }}",
             "spack_manifest_data_pairs": $pairs,
             "spack_compiler_manifest_path": "${{ inputs.spack-compiler-manifest-path }}",
@@ -598,10 +492,10 @@ jobs:
 
             "spec_concretization_graph": $spec,
             "spack_manifest_repository_sha": "${{ steps.checkout.outputs.commit }}",
-            "spack_sha": "${{ steps.spack-update.outputs.sha }}",
-            "spack_config_sha": "${{ steps.spack-config-update.outputs.sha }}",
-            "builtin_spack_packages_sha": "${{ steps.builtin-spack-packages-update.outputs.sha }}",
-            "access_spack_packages_sha": "${{ steps.access-spack-packages-update.outputs.sha }}",
+            "spack_sha": "${{ steps.setup.outputs.spack-sha }}",
+            "spack_config_sha": "${{ steps.setup.outputs.spack-config-sha }}",
+            "builtin_spack_packages_sha": "${{ steps.setup.outputs.builtin-spack-packages-sha }}",
+            "access_spack_packages_sha": "${{ steps.setup.outputs.access-spack-packages-sha }}",
             "caller_sha": "${{ steps.checkout-caller.outputs.commit }}",
             "container_id": "${{ steps.init.outputs.container-id }}",
             "short_container_id": "${{ steps.init.outputs.short-container-id }}",
@@ -637,79 +531,23 @@ jobs:
       tests-error: ${{ steps.test.outputs.error }}
       tests-total: ${{ steps.test.outputs.total }}
     steps:
-      # TODO: Consider bundling the common steps into an action - maybe .github/actions/setup-instance?
-      - name: Init - Export environment variables into GitHub Actions format
-        # Environment variables inside containers are not accessible in the `env` context,
-        # a context which would be used in future conditional steps.
-        # This step exports important container environment variables as outputs.
-        # And yes, this loop echoes name-of-var=value-of-var!
-        id: env
-        run: |
-          for var in SPACK_ROOT INITIAL_SPACK_REPO_VERSION; do
-            echo "$var=${!var}" >> $GITHUB_OUTPUT
-          done
-
-          # The upload step later requires a non-relative path, hence the realpath
-          echo "spack-env-dir=$(realpath $SPACK_ROOT/../environments)" >> $GITHUB_OUTPUT
-
-          # Make sure the artifact directory exists
-          mkdir -p ${{ env.artifact-content-dir }}
-
-      - name: Update - spack-config version
-        id: spack-config-update
-        uses: access-nri/build-ci/.github/actions/git-checkout-updated-ref@v3
+      - name: Init - Clone build-ci for custom actions
+        uses: actions/checkout@v6
         with:
-          repository-path: ${{ steps.env.outputs.SPACK_ROOT }}/../spack-config
-          ref: ${{ inputs.spack-config-ref }}
+          repository: access-nri/build-ci
+          ref: ${{ job.workflow_sha }}
+          path: build-ci
 
-      - name: Update - spack version
-        id: spack-update
-        uses: access-nri/build-ci/.github/actions/git-checkout-updated-ref@v3
+      - name: Setup - Setup and Update Instance
+        id: setup
+        uses: build-ci/.github/actions/setup-instance
         with:
-          repository-path: ${{ steps.env.outputs.SPACK_ROOT }}
-          ref: ${{ inputs.spack-ref }}
-
-      - name: Spack - Enable Runner Set Buildcache
-        if: inputs.run-self-hosted
-        run: |
-          . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
-          spack mirror add --scope=user --autopush --unsigned runner_set_buildcache /opt/runner_set_buildcache
-          spack mirror list
-
-      - name: Spack - Get spack-packages repo locations
-        id: spack-packages-locations
-        run: |
-          . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
-
-          echo "builtin=$(spack location --repo builtin)" >> $GITHUB_OUTPUT
-          echo "access-spack-packages=$(spack location --repo access.nri)" >> $GITHUB_OUTPUT
-
-      - name: Update - builtin spack-package version
-        uses: access-nri/build-ci/.github/actions/spack-checkout-updated-ref@v3
-        with:
-          spack-packages-repository-name: builtin
-          spack-packages-repository-path: ${{ steps.spack-packages-locations.outputs.builtin }}
-          ref: ${{ needs.spack-install.outputs.builtin-spack-packages-sha }}
-          spack-instance-root-path: ${{ steps.env.outputs.SPACK_ROOT }}
-
-      - name: Update - access-spack-package version
-        uses: access-nri/build-ci/.github/actions/spack-checkout-updated-ref@v3
-        with:
-          spack-packages-repository-name: access_spack_packages
-          spack-packages-repository-path: ${{ steps.spack-packages-locations.outputs.access-spack-packages }}
-          ref: ${{ needs.spack-install.outputs.access-spack-packages-sha }}
-          spack-instance-root-path: ${{ steps.env.outputs.SPACK_ROOT }}
-
-      - name: Spack - OCI Buildcache Init
-        if: inputs.spack-oci-buildcache-url != ''
-        run: |
-          . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
-          spack mirror add --scope=user \
-            --unsigned \
-            --oci-username-variable OCI_USERNAME \
-            --oci-password-variable OCI_PASSWORD \
-            oci_buildcache ${{ inputs.spack-oci-buildcache-url }}
-          spack mirror list
+          spack-ref: ${{ inputs.spack-ref }}
+          spack-config-ref: ${{ inputs.spack-config-ref }}
+          builtin-spack-packages-ref: ${{ inputs.builtin-spack-packages-ref }}
+          access-spack-packages-ref: ${{ inputs.access-spack-packages-ref }}
+          spack-oci-buildcache-url: ${{ inputs.spack-oci-buildcache-url }}
+          run-self-hosted: ${{ inputs.run-self-hosted }}
 
       - name: Manifest - Checkout Caller ${{ github.repository }}
         id: checkout-caller
@@ -725,7 +563,15 @@ jobs:
         with:
           repository: ${{ inputs.spack-manifest-repository }}
           ref: ${{ needs.spack-install.outputs.spack-manifest-repository-sha }}
-          submodules: recursive
+          # Only checkout the manifests, rather than the entire repository
+          path: manifest
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |-
+            ${{ inputs.spack-manifest-path }}
+            ${{ inputs.spack-manifest-data-path }}
+            ${{ inputs.spack-compiler-manifest-path }}
+          # Similarly to the spack install command below, we need to be able to checkout the spack-manifest-repository (which may be private)
+          token: ${{ secrets.spack-install-command-pat || github.token }}
 
       - name: Download Install Artifact
         id: download-install-artifact
@@ -742,7 +588,7 @@ jobs:
           OCI_USERNAME: ${{ secrets.spack-oci-buildcache-username || github.actor }}
           OCI_PASSWORD: ${{ secrets.spack-oci-buildcache-password || secrets.GITHUB_TOKEN }}
         run: |
-          . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
+          . ${{ steps.setup.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
           spack env activate local_compilers --create --prompt --envfile ${{ env.artifact-content-dir }}/local_compilers/spack.lock
           spack --debug install --fail-fast --deprecated --use-cache
           spack env deactivate
@@ -763,7 +609,7 @@ jobs:
           GIT_CONFIG_KEY_0: url.https://oauth2:${{ secrets.spack-install-command-pat || secrets.GITHUB_TOKEN }}@github.com/.insteadOf
           GIT_CONFIG_VALUE_0: https://github.com/
         run: |
-          . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
+          . ${{ steps.setup.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
           spack env activate default --create --prompt --envfile ${{ env.artifact-content-dir }}/spack.lock
           spack --debug install --fail-fast --deprecated --use-cache
 
@@ -775,7 +621,7 @@ jobs:
         env:
           pytest-report-path: ${{ env.artifact-content-dir }}/pytest_report.json
         run: |
-          . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
+          . ${{ steps.setup.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
           spack env activate default
           pytest ${{ inputs.pytest-args }} --json-report --json-report-file=${{ env.pytest-report-path }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -629,7 +629,7 @@ jobs:
       volumes:
         # For self-hosted runners, mount the proper upstream and buildcache volumes from the kubernetes cluster
         # For GitHub-hosted runners, mount the dummy volume /dev/null to avoid errors or undefined behavior, eg. fromJson('[]')
-        - ${{ inputs.run-self-hosted && '/opt/upstream-v1:/opt/upstream:ro' || '/dev/null:/dev/null:ro' }}
+        - ${{ inputs.run-self-hosted && '/opt/upstream-v1:/opt/release:ro' || '/dev/null:/dev/null:ro' }}
         - ${{ inputs.run-self-hosted && '/opt/runner_set_buildcache:/opt/runner_set_buildcache:rw' || '/dev/null:/dev/null:ro' }}
     outputs:
       artifact-url: ${{ steps.upload.outputs.artifact-url }}
@@ -670,35 +670,12 @@ jobs:
           repository-path: ${{ steps.env.outputs.SPACK_ROOT }}
           ref: ${{ inputs.spack-ref }}
 
-      - name: Update - Validate and relink spack-config to spack
-        # TODO: Might not be required at all once we move to a different way of doing config...
-        if: steps.spack-config-update.outputs.updated == 'true' || steps.spack-update.outputs.updated == 'true'
-        # If there was a change in spack or spack-config, we should relink the config to spack.
-        # Furthermore, if spack has been updated, we need to make sure we link to the correct vX config directory in spack-config.
-        # We find what branch the spack SHA is part of, and attempt to link to that directory.
+      - name: Spack - Enable Runner Set Buildcache
+        if: inputs.run-self-hosted
         run: |
-          spack_branch=$(git -C ${{ steps.env.outputs.SPACK_ROOT }} for-each-ref --format='%(refname:short)' refs/remotes --contains ${{ steps.spack-update.outputs.sha }} \
-            | grep origin/releases/ \
-            | sed -E 's|^origin/releases/(.+)|\1|' \
-          )
-
-          if [[ $(echo "$spack_branch" | wc -l) -gt 1 ]]; then
-            echo "::error::${{ steps.spack-update.outputs.sha }} is part of multiple spack release branches, and we can't determine which to link spack-config to"
-            exit 2
-          elif [[ -z "$spack_branch" ]]; then
-            echo "::error::${{ steps.spack-update.outputs.sha }} is not part of any spack release branch, so we can't link spack-config to anything"
-            exit 2
-          else
-            echo "Linking spack with SHA ${{ steps.spack-update.outputs.sha }} to spack-config directory $spack_branch"
-          fi
-
-          # Check if the determined spack_branch starts with v0, which is unsupported in build-ci@v3
-          if [[ "$spack_branch" == "v0"* ]]; then
-            echo "::error::spack branch $spack_branch is not a v1.x branch, and build-ci@v3 only supports spack >= v1.0. Use build-ci@v2 for spack < v1.0"
-            exit 2
-          fi
-
-          ln --symbolic --relative --verbose --force ${{ steps.env.outputs.SPACK_ROOT }}/../spack-config/${spack_branch}/ci-runner/* ${{ steps.env.outputs.SPACK_ROOT }}/etc/spack/\
+          . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
+          spack mirror add --scope=user --autopush --unsigned runner_set_buildcache /opt/runner_set_buildcache
+          spack mirror list
 
       - name: Spack - Get spack-packages repo locations
         id: spack-packages-locations
@@ -712,7 +689,7 @@ jobs:
         uses: access-nri/build-ci/.github/actions/spack-checkout-updated-ref@v3
         with:
           spack-packages-repository-name: builtin
-          spack-packages-repository-path: ${{ steps.spack-packages-locations.outputs.builtin-spack-packages-location }}
+          spack-packages-repository-path: ${{ steps.spack-packages-locations.outputs.builtin }}
           ref: ${{ needs.spack-install.outputs.builtin-spack-packages-sha }}
           spack-instance-root-path: ${{ steps.env.outputs.SPACK_ROOT }}
 
@@ -720,7 +697,7 @@ jobs:
         uses: access-nri/build-ci/.github/actions/spack-checkout-updated-ref@v3
         with:
           spack-packages-repository-name: access_spack_packages
-          spack-packages-repository-path: ${{ steps.spack-packages-locations.outputs.access-spack-packages-location }}
+          spack-packages-repository-path: ${{ steps.spack-packages-locations.outputs.access-spack-packages }}
           ref: ${{ needs.spack-install.outputs.access-spack-packages-sha }}
           spack-instance-root-path: ${{ steps.env.outputs.SPACK_ROOT }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -638,14 +638,14 @@ jobs:
         run: |
           jq --null-input \
             --slurpfile outputs ${{ env.artifact-content-dir }}/job_outputs.json \
-            '$outputs + {
+            '$outputs[] + {
               "test_build_result" : "${{ steps.test.outcome }}",
               "tests_passed": ${{ steps.results.outputs.passed }},
               "tests_failed": ${{ steps.results.outputs.failed }},
               "tests_error": ${{ steps.results.outputs.error }},
               "tests_total": ${{ steps.results.outputs.total }}
             }' \
-            ${{ env.artifact-content-dir }}/job_outputs.json.tmp
+            > ${{ env.artifact-content-dir }}/job_outputs.json.tmp
 
           mv ${{ env.artifact-content-dir }}/job_outputs.json.tmp ${{ env.artifact-content-dir }}/job_outputs.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,18 +188,16 @@ on:
           The short ID of the container where the spack packages have been installed - used for artifact disambiguation.
       ## These outputs contain information on data uploaded as artifacts
       artifact-pattern:
+        # This stays the same whether test-build ran, so we just take it from the first job in the workflow
         value: ${{ jobs.spack-install.outputs.artifact-pattern }}
         description: |
           Wildcard pattern to match all artifacts across a matrix job.
       artifact-url:
-        value: ${{ jobs.spack-install.outputs.artifact-url }}
+        # The artifact url may change if test-build ran and overwrote it - so we take the one from test-build if it exists, and otherwise take it from spack-install
+        value: ${{ jobs.test-build.outputs.artifact-url || jobs.spack-install.outputs.artifact-url }}
         description: |
           The URL of the artifact, which contains all outputs of the job.
           This contains spack files and outputs of the job itself for post-matrix processing.
-      # test-artifact-url:
-      #   value: ${{}}
-      #   description: |
-      #     The URL of the pytest result artifact.
 env:
   # Common directory for outputs to be added to artifact
   artifact-content-dir: /tmp/artifact-output
@@ -634,8 +632,11 @@ jobs:
         - ${{ inputs.run-self-hosted && '/opt/upstream-v1:/opt/upstream:ro' || '/dev/null:/dev/null:ro' }}
         - ${{ inputs.run-self-hosted && '/opt/runner_set_buildcache:/opt/runner_set_buildcache:rw' || '/dev/null:/dev/null:ro' }}
     outputs:
-      artifact-pattern: ${{ needs.spack-install.outputs.artifact-pattern }}
       artifact-url: ${{ steps.upload.outputs.artifact-url }}
+      tests-passed: ${{ steps.test.outputs.passed }}
+      tests-failed: ${{ steps.test.outputs.failed }}
+      tests-error: ${{ steps.test.outputs.error }}
+      tests-total: ${{ steps.test.outputs.total }}
     steps:
       # TODO: Consider bundling the common steps into an action - maybe .github/actions/setup-instance?
       - name: Init - Export environment variables into GitHub Actions format
@@ -787,10 +788,17 @@ jobs:
 
       - name: Test - Pytest
         id: test
+        env:
+          pytest-report-path: ${{ env.artifact-content-dir }}/pytest_report.json
         run: |
           . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
           spack env activate default
-          pytest ${{ inputs.pytest-args }} --json-report --json-report-file=${{ env.artifact-content-dir }}/pytest_report.json
+          pytest ${{ inputs.pytest-args }} --json-report --json-report-file=${{ env.pytest-report-path }}
+
+          echo "passed=$(jq --raw-output '.summary.passed' ${{ env.pytest-report-path }})" >> $GITHUB_OUTPUT
+          echo "failed=$(jq --raw-output '.summary.failed' ${{ env.pytest-report-path }})" >> $GITHUB_OUTPUT
+          echo "error=$(jq --raw-output '.summary.error' ${{ env.pytest-report-path }})" >> $GITHUB_OUTPUT
+          echo "total=$(jq --raw-output '.summary.total' ${{ env.pytest-report-path }})" >> $GITHUB_OUTPUT
 
       - name: Outputs - Consolidate Job Outputs
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ on:
       caller-sha:
         value: ${{ jobs.spack-install.outputs.caller-sha }}
         description: |
-          The SHA of the caller model component repository checked out.
+          The SHA of the package under test.
       container-id:
         value: ${{ jobs.spack-install.outputs.container-id }}
         description: |
@@ -553,7 +553,9 @@ jobs:
         id: checkout-caller
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
+          # The default ref is the merge commit for pull requests, which isn't able to be checked out locally
+          # (and is therefore useless outside of the workflow run), so we get the PR head instead. See https://github.com/orgs/community/discussions/26325
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           submodules: recursive
           path: caller
 
@@ -592,10 +594,7 @@ jobs:
           spack env activate local_compilers --create --prompt --envfile ${{ env.artifact-content-dir }}/local_compilers/spack.lock
           spack --debug install --fail-fast --deprecated --use-cache
           spack env deactivate
-          yq '.spack.specs[]' ${{ env.artifact-content-dir }}/local_compilers/spack.lock | while read compiler; do
-            spack load $compiler
-            spack compiler find --scope=user
-          done
+
           spack compiler list
 
       - name: Manifest - Install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,18 @@ on:
         description: |
           Whether to run the job on a self-hosted runner.
           For security, workflow runs will hang if this is true but it is not using a valid v* branch or tag for the workflow ref.
+      enable-pytest:
+        type: boolean
+        required: false
+        default: false
+        description: |
+          Whether to enable post-build testing of the manifest.
+          All visible pytests under inputs.spack-manifest-repository will be run.
+      pytest-args:
+        type: string
+        required: false
+        description: |
+          A list of pytest flags to affect the invocation of pytest. For example, addition of markers with '-m "marker_one and marker_two"'
     secrets:
       spack-install-command-pat:
         required: false
@@ -139,48 +151,48 @@ on:
           A password (or GitHub PAT for oci://ghcr.io buildcaches) to use for reading and writing to the spack OCI buildcache, if inputs.spack-oci-buildcache-url is defined.
     outputs:
       spec-concretization-graph:
-        value: ${{jobs.spack-install-and-test.outputs.spec-concretization-graph }}
+        value: ${{jobs.spack-install.outputs.spec-concretization-graph }}
         description: |
           A visual representation of the dependencies and constraints of the spack manifest file installed.
       spack-manifest-repository-sha:
-        value: ${{ jobs.spack-install-and-test.outputs.spack-manifest-repository-sha }}
+        value: ${{ jobs.spack-install.outputs.spack-manifest-repository-sha }}
         description: |
           The SHA of the spack manifest repository checked out.
       spack-sha:
-        value: ${{ jobs.spack-install-and-test.outputs.spack-sha }}
+        value: ${{ jobs.spack-install.outputs.spack-sha }}
         description: |
           The SHA of the spack repository checked out.
       spack-config-sha:
-        value: ${{ jobs.spack-install-and-test.outputs.spack-config-sha }}
+        value: ${{ jobs.spack-install.outputs.spack-config-sha }}
         description: |
           The SHA of the spack-config repository checked out.
       builtin-spack-packages-sha:
-        value: ${{ jobs.spack-install-and-test.outputs.builtin-spack-packages-sha }}
+        value: ${{ jobs.spack-install.outputs.builtin-spack-packages-sha }}
         description: |
           The SHA of the builtin spack-packages repository checked out.
       access-spack-packages-sha:
-        value: ${{ jobs.spack-install-and-test.outputs.access-spack-packages-sha }}
+        value: ${{ jobs.spack-install.outputs.access-spack-packages-sha }}
         description: |
           The SHA of the access-spack-packages repository checked out.
       caller-sha:
-        value: ${{ jobs.spack-install-and-test.outputs.caller-sha }}
+        value: ${{ jobs.spack-install.outputs.caller-sha }}
         description: |
           The SHA of the caller model component repository checked out.
       container-id:
-        value: ${{ jobs.spack-install-and-test.outputs.container-id }}
+        value: ${{ jobs.spack-install.outputs.container-id }}
         description: |
           The ID of the container where the spack packages have been installed.
       short-container-id:
-        value: ${{ jobs.spack-install-and-test.outputs.short-container-id }}
+        value: ${{ jobs.spack-install.outputs.short-container-id }}
         description: |
           The short ID of the container where the spack packages have been installed - used for artifact disambiguation.
       ## These outputs contain information on data uploaded as artifacts
       artifact-pattern:
-        value: ${{ jobs.spack-install-and-test.outputs.artifact-pattern }}
+        value: ${{ jobs.spack-install.outputs.artifact-pattern }}
         description: |
           Wildcard pattern to match all artifacts across a matrix job.
       artifact-url:
-        value: ${{ jobs.spack-install-and-test.outputs.artifact-url }}
+        value: ${{ jobs.spack-install.outputs.artifact-url }}
         description: |
           The URL of the artifact, which contains all outputs of the job.
           This contains spack files and outputs of the job itself for post-matrix processing.
@@ -188,9 +200,12 @@ on:
       #   value: ${{}}
       #   description: |
       #     The URL of the pytest result artifact.
+env:
+  # Common directory for outputs to be added to artifact
+  artifact-content-dir: /tmp/artifact-output
 jobs:
-  spack-install-and-test:
-    name: Install and Test
+  spack-install:
+    name: Install
     runs-on: ${{ inputs.run-self-hosted && fromJson('{"group":"build-ci"}') || 'ubuntu-latest' }}
     container:
       image: ghcr.io/access-nri/build-ci-runner${{ inputs.container-image-version }}
@@ -200,6 +215,7 @@ jobs:
         - ${{ inputs.run-self-hosted && '/opt/upstream-v1:/opt/release:ro' || '/dev/null:/dev/null:ro' }}
         - ${{ inputs.run-self-hosted && '/opt/runner_set_buildcache:/opt/runner_set_buildcache:rw' || '/dev/null:/dev/null:ro' }}
     outputs:
+      # Job outputs outputted as workflow output
       spec-concretization-graph: ${{ steps.install.outputs.spec }}
       spack-manifest-repository-sha: ${{ steps.checkout.outputs.commit }}
       spack-sha: ${{ steps.spack-update.outputs.sha }}
@@ -211,10 +227,10 @@ jobs:
       artifact-url: ${{ steps.upload.outputs.artifact-url }}
       container-id: ${{ steps.init.outputs.container-id }}
       short-container-id: ${{ steps.init.outputs.short-container-id }}
-      # test-artifact-url: ${{ steps.test.outputs.artifact-url }}
-    env:
-      # Common directory for outputs to be added to artifact
-      artifact-content-dir: /tmp/artifact-output
+      # Job outputs only used in the test job
+      artifact-name: ${{ steps.init.outputs.artifact-name }}
+      builtin-spack-packages-location: ${{ steps.spack-packages-locations.outputs.builtin }}
+      access-spack-packages-location: ${{ steps.spack-packages-locations.outputs.access-spack-packages }}
     steps:
       - name: Init - Clone build-ci for custom actions
         uses: actions/checkout@v6
@@ -517,23 +533,20 @@ jobs:
           # Our runner container has tmate pre-installed
           install-dependencies: false
 
-      # TODO: Add pytest infrastructure
-      # - name: Run pytests
-      #   id: test
-      #   run: |
-      #     python -m pytest -v -m "${{ inputs.pytest-test-markers }}" --junitxml=pytest.xml
-      #     echo "pytest=$(cat pytest.xml)" >> $GITHUB_OUTPUT
-
-
       - name: Outputs - Consolidate Spack Outputs
         if: always() && (steps.install.conclusion == 'failure' || steps.install.conclusion == 'success')
         # Logs or manifests may not be available if the spack install failed before concretization, so we'd rather direct users to the
         # above install failure than have this step fail.
         continue-on-error: true
         run: |
-          # Consolidate Manifest
+          # Consolidate Manifests
           if compgen -G "${{ steps.env.outputs.spack-env-dir }}/default/spack.*" > /dev/null; then
             cp -v ${{ steps.env.outputs.spack-env-dir }}/default/spack.* ${{ env.artifact-content-dir }}
+          fi
+
+          if compgen -G "${{ steps.env.outputs.spack-env-dir }}/local_compilers/spack.*" > /dev/null; then
+            mkdir -p ${{ env.artifact-content-dir }}/local_compilers
+            cp -v ${{ steps.env.outputs.spack-env-dir }}/local_compilers/spack.* ${{ env.artifact-content-dir }}/local_compilers
           fi
 
           # Consolidate Logs
@@ -605,3 +618,204 @@ jobs:
           name: ${{ steps.init.outputs.artifact-name }}
           path: ${{ env.artifact-content-dir }}
           if-no-files-found: error
+
+  test-build:
+    name: Test
+    runs-on: ${{ inputs.run-self-hosted && fromJson('{"group":"build-ci"}') || 'ubuntu-latest' }}
+    needs:
+      - spack-install
+    if: inputs.enable-pytest
+    container:
+      # FIXME: This probably will be changed once there is a update to use only build-ci-runner
+      image: ${{ inputs.run-self-hosted && 'ghcr.io/access-nri/build-ci-runner' || 'ghcr.io/access-nri/build-ci-upstream' }}${{ inputs.container-image-version }}
+      volumes:
+        # For self-hosted runners, mount the proper upstream and buildcache volumes from the kubernetes cluster
+        # For GitHub-hosted runners, mount the dummy volume /dev/null to avoid errors or undefined behavior, eg. fromJson('[]')
+        - ${{ inputs.run-self-hosted && '/opt/upstream-v1:/opt/upstream:ro' || '/dev/null:/dev/null:ro' }}
+        - ${{ inputs.run-self-hosted && '/opt/runner_set_buildcache:/opt/runner_set_buildcache:rw' || '/dev/null:/dev/null:ro' }}
+    outputs:
+      artifact-pattern: ${{ needs.spack-install.outputs.artifact-pattern }}
+      artifact-url: ${{ steps.upload.outputs.artifact-url }}
+    steps:
+      # TODO: Consider bundling the common steps into an action - maybe .github/actions/setup-instance?
+      - name: Init - Export environment variables into GitHub Actions format
+        # Environment variables inside containers are not accessible in the `env` context,
+        # a context which would be used in future conditional steps.
+        # This step exports important container environment variables as outputs.
+        # And yes, this loop echoes name-of-var=value-of-var!
+        id: env
+        run: |
+          for var in SPACK_ROOT INITIAL_SPACK_REPO_VERSION; do
+            echo "$var=${!var}" >> $GITHUB_OUTPUT
+          done
+
+          # The upload step later requires a non-relative path, hence the realpath
+          echo "spack-env-dir=$(realpath $SPACK_ROOT/../environments)" >> $GITHUB_OUTPUT
+
+          # Make sure the artifact directory exists
+          mkdir -p ${{ env.artifact-content-dir }}
+
+      - name: Update - spack-config version
+        id: spack-config-update
+        uses: access-nri/build-ci/.github/actions/git-checkout-updated-ref@v3
+        with:
+          repository-path: ${{ steps.env.outputs.SPACK_ROOT }}/../spack-config
+          ref: ${{ inputs.spack-config-ref }}
+
+      - name: Update - spack version
+        id: spack-update
+        uses: access-nri/build-ci/.github/actions/git-checkout-updated-ref@v3
+        with:
+          repository-path: ${{ steps.env.outputs.SPACK_ROOT }}
+          ref: ${{ inputs.spack-ref }}
+
+      - name: Update - Validate and relink spack-config to spack
+        # TODO: Might not be required at all once we move to a different way of doing config...
+        if: steps.spack-config-update.outputs.updated == 'true' || steps.spack-update.outputs.updated == 'true'
+        # If there was a change in spack or spack-config, we should relink the config to spack.
+        # Furthermore, if spack has been updated, we need to make sure we link to the correct vX config directory in spack-config.
+        # We find what branch the spack SHA is part of, and attempt to link to that directory.
+        run: |
+          spack_branch=$(git -C ${{ steps.env.outputs.SPACK_ROOT }} for-each-ref --format='%(refname:short)' refs/remotes --contains ${{ steps.spack-update.outputs.sha }} \
+            | grep origin/releases/ \
+            | sed -E 's|^origin/releases/(.+)|\1|' \
+          )
+
+          if [[ $(echo "$spack_branch" | wc -l) -gt 1 ]]; then
+            echo "::error::${{ steps.spack-update.outputs.sha }} is part of multiple spack release branches, and we can't determine which to link spack-config to"
+            exit 2
+          elif [[ -z "$spack_branch" ]]; then
+            echo "::error::${{ steps.spack-update.outputs.sha }} is not part of any spack release branch, so we can't link spack-config to anything"
+            exit 2
+          else
+            echo "Linking spack with SHA ${{ steps.spack-update.outputs.sha }} to spack-config directory $spack_branch"
+          fi
+
+          # Check if the determined spack_branch starts with v0, which is unsupported in build-ci@v3
+          if [[ "$spack_branch" == "v0"* ]]; then
+            echo "::error::spack branch $spack_branch is not a v1.x branch, and build-ci@v3 only supports spack >= v1.0. Use build-ci@v2 for spack < v1.0"
+            exit 2
+          fi
+
+          ln --symbolic --relative --verbose --force ${{ steps.env.outputs.SPACK_ROOT }}/../spack-config/${spack_branch}/ci-runner/* ${{ steps.env.outputs.SPACK_ROOT }}/etc/spack/\
+
+      - name: Update - builtin spack-package version
+        uses: access-nri/build-ci/.github/actions/spack-checkout-updated-ref@v3
+        with:
+          spack-packages-repository-name: builtin
+          spack-packages-repository-path: ${{ needs.spack-install.outputs.builtin-spack-packages-location }}
+          ref: ${{ needs.spack-install.outputs.builtin-spack-packages-sha }}
+          spack-instance-root-path: ${{ steps.env.outputs.SPACK_ROOT }}
+
+      - name: Update - access-spack-package version
+        uses: access-nri/build-ci/.github/actions/spack-checkout-updated-ref@v3
+        with:
+          spack-packages-repository-name: access_spack_packages
+          spack-packages-repository-path: ${{ needs.spack-install.outputs.access-spack-packages-location }}
+          ref: ${{ needs.spack-install.outputs.access-spack-packages-sha }}
+          spack-instance-root-path: ${{ steps.env.outputs.SPACK_ROOT }}
+
+      - name: Spack - OCI Buildcache Init
+        if: inputs.spack-oci-buildcache-url != ''
+        run: |
+          . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
+          spack mirror add --scope=user \
+            --unsigned \
+            --oci-username-variable OCI_USERNAME \
+            --oci-password-variable OCI_PASSWORD \
+            oci_buildcache ${{ inputs.spack-oci-buildcache-url }}
+          spack mirror list
+
+      - name: Manifest - Checkout Caller ${{ github.repository }}
+        id: checkout-caller
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          submodules: recursive
+          path: caller
+
+      - name: Manifest - Checkout Manifest From ${{ inputs.spack-manifest-repository }}
+        id: checkout
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.spack-manifest-repository }}
+          ref: ${{ needs.spack-install.outputs.spack-manifest-repository-sha }}
+          submodules: recursive
+
+      - name: Download Install Artifact
+        id: download-install-artifact
+        uses: actions/download-artifact@v6
+        with:
+          name: ${{ needs.spack-install.outputs.artifact-url }}
+          path: ${{ env.artifact-content-dir }}
+
+      - name: Manifest - Install Compilers Locally
+        # Some compilers may not be available upstream, so we install them locally in a separate spack.yaml
+        if: inputs.spack-compiler-manifest-path != ''
+        env:
+          # For pulling OCI buildcache
+          OCI_USERNAME: ${{ secrets.spack-oci-buildcache-username || github.actor }}
+          OCI_PASSWORD: ${{ secrets.spack-oci-buildcache-password || secrets.GITHUB_TOKEN }}
+        run: |
+          . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
+          spack env activate local_compilers --create --prompt --envfile ${{ env.artifact-content-dir }}/local_compilers/spack.lock
+          spack --debug install --fail-fast --deprecated --use-cache
+          spack env deactivate
+          yq '.spack.specs[]' ${{ env.artifact-content-dir }}/local_compilers/spack.lock | while read compiler; do
+            spack load $compiler
+            spack compiler find --scope=user
+          done
+          spack compiler list
+
+      - name: Manifest - Install
+        env:
+          # For pulling OCI buildcache
+          OCI_USERNAME: ${{ secrets.spack-oci-buildcache-username || github.actor }}
+          OCI_PASSWORD: ${{ secrets.spack-oci-buildcache-password || secrets.GITHUB_TOKEN }}
+          # This is needed to ensure that the spack install command can access private repositories - we replace all HTTPS git URLs with the PAT
+          # We set the git config via environment variables, so that the PATs are not persisted in the container
+          GIT_CONFIG_COUNT: 1
+          GIT_CONFIG_KEY_0: url.https://oauth2:${{ secrets.spack-install-command-pat || secrets.GITHUB_TOKEN }}@github.com/.insteadOf
+          GIT_CONFIG_VALUE_0: https://github.com/
+        run: |
+          . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
+          spack env activate default --create --prompt --envfile ${{ env.artifact-content-dir }}/spack.lock
+          spack --debug install --fail-fast --deprecated --use-cache
+
+      - name: Test - Install pytest
+        run: python3 -m pip install pytest pytest-json-report
+
+      - name: Test - Pytest
+        id: test
+        run: |
+          . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
+          spack env activate default
+          pytest ${{ inputs.pytest-args }} --json-report --json-report-file=${{ env.artifact-content-dir }}/pytest_report.json
+
+      - name: Outputs - Consolidate Job Outputs
+        run: |
+          jq --null-input \
+            --slurpfile outputs ${{ env.artifact-content-dir }}/job_outputs.json \
+            --slurpfile report ${{ env.artifact-content-dir }}/pytest_report.json \
+            '$outputs + {
+              "test_build_result" : "${{ steps.test.outcome }}",
+              "tests_passed": $report[].summary.passed // 0,
+              "tests_failed": $report[].summary.failed // 0,
+              "tests_error": $report[].summary.error // 0,
+              "tests_total": $report[].summary.total // 0
+            }' \
+            ${{ env.artifact-content-dir }}/job_outputs.json.tmp
+
+          mv ${{ env.artifact-content-dir }}/job_outputs.json.tmp ${{ env.artifact-content-dir }}/job_outputs.json
+
+      - name: Outputs - Upload
+        if: always()
+        id: upload
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ needs.spack-install.outputs.artifact-name }}
+          path: ${{ env.artifact-content-dir }}
+          if-no-files-found: error
+          # As we're recreating the artifact with the additional test outputs,
+          # we need to overwrite the artifact uploaded by the install job
+          overwrite: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -613,6 +613,12 @@ jobs:
           spack env activate default --create --prompt --envfile ${{ env.artifact-content-dir }}/spack.lock
           spack --debug install --fail-fast --deprecated --use-cache
 
+      - name: Test - Install Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          cache: pip
+          python-version: 3.11
+
       - name: Test - Install pytest
         run: python3 -m pip install pytest pytest-json-report
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: ${{ inputs.spack-manifest-repository }}
-          ref: ${{ steps.setup.outputs.spack-manifest-repository-ref }}
+          ref: ${{ steps.init.outputs.spack-manifest-repository-ref }}
           # Only checkout the manifests, rather than the entire repository
           path: manifest
           sparse-checkout-cone-mode: false
@@ -474,7 +474,7 @@ jobs:
           '{
             "spack_manifest_path": "${{ inputs.spack-manifest-path }}",
             "spack_manifest_repository": "${{ inputs.spack-manifest-repository }}",
-            "spack_manifest_repository_ref": "${{ steps.setup.outputs.spack-manifest-repository-ref }}",
+            "spack_manifest_repository_ref": "${{ steps.init.outputs.spack-manifest-repository-ref }}",
             "spack_manifest_data_path": "${{ inputs.spack-manifest-data-path }}",
             "spack_manifest_data_pairs": $pairs,
             "spack_compiler_manifest_path": "${{ inputs.spack-compiler-manifest-path }}",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -615,22 +615,21 @@ jobs:
           spack env activate default --create --prompt --envfile ${{ env.artifact-content-dir }}/spack.lock
           spack --debug install --fail-fast --deprecated --use-cache
 
-      - name: Test - Install pytest
+      - name: Test - Install pytest requirements
         working-directory: manifest
         env:
           PYTEST_VERSION: 9.1.1
           PYTEST_JSON_REPORT_VERSION: 1.5.0
         run: |
-          python3 -m venv .ci-venv
-          . .ci-venv/bin/activate
-          pip install pytest==${{ env.PYTEST_VERSION }} pytest-json-report==${{ env.PYTEST_JSON_REPORT_VERSION }}
+          . ${{ steps.setup.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
+          spack env activate default
 
-      - name: Test - Install Optional Requirements
-        if: inputs.pytest-requirements-path != ''
-        working-directory: manifest
-        run: |
+          python3 -m venv --system-site-packages .ci-venv
           . .ci-venv/bin/activate
-          pip install -r ${{ inputs.pytest-requirements-path }}
+
+          pip install \
+            pytest==${{ env.PYTEST_VERSION }} pytest-json-report==${{ env.PYTEST_JSON_REPORT_VERSION }} \
+            ${{ inputs.pytest-requirements-path && format('-r {0}', inputs.pytest-requirements-path) }}
 
       - name: Test - Read Potential Pytest Args From Reserved Definitions
         id: reserved-defs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -786,6 +786,7 @@ jobs:
           echo "total=$(jq --raw-output '.summary.total' ${{ env.pytest-report-path }})" >> $GITHUB_OUTPUT
 
       - name: Outputs - Consolidate Job Outputs
+        if: always() && steps.test.outcome != 'skipped'
         run: |
           jq --null-input \
             --slurpfile outputs ${{ env.artifact-content-dir }}/job_outputs.json \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,8 +227,8 @@ jobs:
       short-container-id: ${{ steps.init.outputs.short-container-id }}
       # Job outputs only used in the test job
       artifact-name: ${{ steps.init.outputs.artifact-name }}
-      builtin-spack-packages-location: ${{ steps.spack-packages-locations.outputs.builtin }}
-      access-spack-packages-location: ${{ steps.spack-packages-locations.outputs.access-spack-packages }}
+      # builtin-spack-packages-location: ${{ steps.spack-packages-locations.outputs.builtin }}
+      # access-spack-packages-location: ${{ steps.spack-packages-locations.outputs.access-spack-packages }}
     steps:
       - name: Init - Clone build-ci for custom actions
         uses: actions/checkout@v6
@@ -700,11 +700,19 @@ jobs:
 
           ln --symbolic --relative --verbose --force ${{ steps.env.outputs.SPACK_ROOT }}/../spack-config/${spack_branch}/ci-runner/* ${{ steps.env.outputs.SPACK_ROOT }}/etc/spack/\
 
+      - name: Spack - Get spack-packages repo locations
+        id: spack-packages-locations
+        run: |
+          . ${{ steps.env.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
+
+          echo "builtin=$(spack location --repo builtin)" >> $GITHUB_OUTPUT
+          echo "access-spack-packages=$(spack location --repo access.nri)" >> $GITHUB_OUTPUT
+
       - name: Update - builtin spack-package version
         uses: access-nri/build-ci/.github/actions/spack-checkout-updated-ref@v3
         with:
           spack-packages-repository-name: builtin
-          spack-packages-repository-path: ${{ needs.spack-install.outputs.builtin-spack-packages-location }}
+          spack-packages-repository-path: ${{ steps.spack-packages-locations.outputs.builtin-spack-packages-location }}
           ref: ${{ needs.spack-install.outputs.builtin-spack-packages-sha }}
           spack-instance-root-path: ${{ steps.env.outputs.SPACK_ROOT }}
 
@@ -712,7 +720,7 @@ jobs:
         uses: access-nri/build-ci/.github/actions/spack-checkout-updated-ref@v3
         with:
           spack-packages-repository-name: access_spack_packages
-          spack-packages-repository-path: ${{ needs.spack-install.outputs.access-spack-packages-location }}
+          spack-packages-repository-path: ${{ steps.spack-packages-locations.outputs.access-spack-packages-location }}
           ref: ${{ needs.spack-install.outputs.access-spack-packages-sha }}
           spack-instance-root-path: ${{ steps.env.outputs.SPACK_ROOT }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -732,7 +732,7 @@ jobs:
         id: download-install-artifact
         uses: actions/download-artifact@v6
         with:
-          name: ${{ needs.spack-install.outputs.artifact-url }}
+          name: ${{ needs.spack-install.outputs.artifact-name }}
           path: ${{ env.artifact-content-dir }}
 
       - name: Manifest - Install Compilers Locally

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -637,6 +637,7 @@ jobs:
 
           . ${{ steps.setup.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
           spack env activate default
+          . .ci-venv/bin/activate
           pytest ${{ inputs.pytest-search-path }} \
             ${{ steps.reserved-defs.outputs.args }} \
             --json-report --json-report-file=$json_report_path \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,14 @@ on:
         default: false
         description: |
           Whether to enable post-build testing of the manifest.
-          All visible pytests under inputs.spack-manifest-repository will be run.
+      pytest-search-path:
+        type: string
+        required: false
+        default: .
+        description: |
+          The path to search for pytest tests, relative to the caller repository root.
+          Note that hidden directories are not searched in this default.
+          For example: .github/build/tests.
     secrets:
       spack-install-command-pat:
         required: false
@@ -625,7 +632,9 @@ jobs:
 
           . ${{ steps.setup.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
           spack env activate default
-          pytest ${{ steps.reserved-defs.outputs.args }} --json-report --json-report-file=$report_path
+          pytest ${{ inputs.pytest-search-path }} \
+            ${{ steps.reserved-defs.outputs.args }} \
+            --json-report --json-report-file=$report_path
 
       - name: Test - Results
         id: results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -627,23 +627,38 @@ jobs:
       - name: Test - Pytest
         id: test
         run: |
-          report_path=${{ env.artifact-content-dir }}/pytest_report.json
-          echo "report-path=$report_path" >> $GITHUB_OUTPUT
+          json_report_path=${{ env.artifact-content-dir }}/pytest_report.json
+          xml_report_path=${{ env.artifact-content-dir }}/pytest_report.xml
+          echo "json-report-path=$json_report_path" >> $GITHUB_OUTPUT
+          echo "xml-report-path=$xml_report_path" >> $GITHUB_OUTPUT
 
           . ${{ steps.setup.outputs.SPACK_ROOT }}/share/spack/setup-env.sh
           spack env activate default
           pytest ${{ inputs.pytest-search-path }} \
             ${{ steps.reserved-defs.outputs.args }} \
-            --json-report --json-report-file=$report_path
+            --json-report --json-report-file=$json_report_path \
+            --junit-xml=$xml_report_path
 
       - name: Test - Results
         id: results
         if: always() && steps.test.outcome != 'skipped'
         run: |
-          echo "passed=$(jq --raw-output '.summary.passed // 0' ${{ steps.test.outputs.report-path }})" >> $GITHUB_OUTPUT
-          echo "failed=$(jq --raw-output '.summary.failed // 0' ${{ steps.test.outputs.report-path }})" >> $GITHUB_OUTPUT
-          echo "error=$(jq --raw-output '.summary.error // 0' ${{ steps.test.outputs.report-path }})" >> $GITHUB_OUTPUT
-          echo "total=$(jq --raw-output '.summary.total // 0' ${{ steps.test.outputs.report-path }})" >> $GITHUB_OUTPUT
+          echo "passed=$(jq --raw-output '.summary.passed // 0' ${{ steps.test.outputs.json-report-path }})" >> $GITHUB_OUTPUT
+          echo "failed=$(jq --raw-output '.summary.failed // 0' ${{ steps.test.outputs.json-report-path }})" >> $GITHUB_OUTPUT
+          echo "error=$(jq --raw-output '.summary.error // 0' ${{ steps.test.outputs.json-report-path }})" >> $GITHUB_OUTPUT
+          echo "total=$(jq --raw-output '.summary.total // 0' ${{ steps.test.outputs.json-report-path }})" >> $GITHUB_OUTPUT
+
+      - name: Test- Parse Test Report
+        id: tests
+        uses: EnricoMi/publish-unit-test-result-action/linux@c950f6fb443cb5af20a377fd0dfaa78838901040  #v2.23.0
+        with:
+          files: ${{ steps.test.outputs.xml-report-path }}
+          comment_mode: off
+          check_run: true
+          check_name: Pytest Results
+          compare_to_earlier_commit: false
+          report_individual_runs: true
+          report_suite_logs: any
 
       - name: Outputs - Consolidate Job Outputs
         if: always() && steps.test.outcome != 'skipped'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,8 +227,6 @@ jobs:
       short-container-id: ${{ steps.init.outputs.short-container-id }}
       # Job outputs only used in the test job
       artifact-name: ${{ steps.init.outputs.artifact-name }}
-      # builtin-spack-packages-location: ${{ steps.spack-packages-locations.outputs.builtin }}
-      # access-spack-packages-location: ${{ steps.spack-packages-locations.outputs.access-spack-packages }}
     steps:
       - name: Init - Clone build-ci for custom actions
         uses: actions/checkout@v6
@@ -625,23 +623,22 @@ jobs:
           spack env activate default
           pytest ${{ inputs.pytest-args }} --json-report --json-report-file=${{ env.pytest-report-path }}
 
-          echo "passed=$(jq --raw-output '.summary.passed' ${{ env.pytest-report-path }})" >> $GITHUB_OUTPUT
-          echo "failed=$(jq --raw-output '.summary.failed' ${{ env.pytest-report-path }})" >> $GITHUB_OUTPUT
-          echo "error=$(jq --raw-output '.summary.error' ${{ env.pytest-report-path }})" >> $GITHUB_OUTPUT
-          echo "total=$(jq --raw-output '.summary.total' ${{ env.pytest-report-path }})" >> $GITHUB_OUTPUT
+          echo "passed=$(jq --raw-output '.summary.passed // 0' ${{ env.pytest-report-path }})" >> $GITHUB_OUTPUT
+          echo "failed=$(jq --raw-output '.summary.failed // 0' ${{ env.pytest-report-path }})" >> $GITHUB_OUTPUT
+          echo "error=$(jq --raw-output '.summary.error // 0' ${{ env.pytest-report-path }})" >> $GITHUB_OUTPUT
+          echo "total=$(jq --raw-output '.summary.total // 0' ${{ env.pytest-report-path }})" >> $GITHUB_OUTPUT
 
       - name: Outputs - Consolidate Job Outputs
         if: always() && steps.test.outcome != 'skipped'
         run: |
           jq --null-input \
             --slurpfile outputs ${{ env.artifact-content-dir }}/job_outputs.json \
-            --slurpfile report ${{ env.artifact-content-dir }}/pytest_report.json \
             '$outputs + {
               "test_build_result" : "${{ steps.test.outcome }}",
-              "tests_passed": $report[].summary.passed // 0,
-              "tests_failed": $report[].summary.failed // 0,
-              "tests_error": $report[].summary.error // 0,
-              "tests_total": $report[].summary.total // 0
+              "tests_passed": ${{ steps.test.outputs.passed }},
+              "tests_failed": ${{ steps.test.outputs.failed }},
+              "tests_error": ${{ steps.test.outputs.error }},
+              "tests_total": ${{ steps.test.outputs.total }}
             }' \
             ${{ env.artifact-content-dir }}/job_outputs.json.tmp
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -623,6 +623,12 @@ jobs:
           spack env activate default
           pytest ${{ inputs.pytest-args }} --json-report --json-report-file=${{ env.pytest-report-path }}
 
+          jq --raw-output '.summary' ${{ env.pytest-report-path }}
+          jq --raw-output '.summary.passed // 0' ${{ env.pytest-report-path }}
+          jq --raw-output '.summary.failed // 0' ${{ env.pytest-report-path }}
+          jq --raw-output '.summary.error // 0' ${{ env.pytest-report-path }}
+          jq --raw-output '.summary.total // 0' ${{ env.pytest-report-path }}
+
           echo "passed=$(jq --raw-output '.summary.passed // 0' ${{ env.pytest-report-path }})" >> $GITHUB_OUTPUT
           echo "failed=$(jq --raw-output '.summary.failed // 0' ${{ env.pytest-report-path }})" >> $GITHUB_OUTPUT
           echo "error=$(jq --raw-output '.summary.error // 0' ${{ env.pytest-report-path }})" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Closes #193 

## Background

Right now, we install the component manifests but don't do any testing outside of the installation status of `spack`. We need a framework for post-build testing, and right now we're going with `pytest` due to the strength of test specification via `--marker`s, it's use as a testing meta-framework in other repositories such as `ACCESS-NRI/model-config-tests`, and it's integration with GitHub Actions. 

Essentially we will have a second job (`Test`) after the first (`Install`), that will reinstall the lockfile via a buildcache, then discover all tests in the MCR, and run them. Users can specify args to `pytest` at the manifest level via a reserved definition `_pytest-args`, like so:

```yaml
spack:
  definitions:
  - _pytest-args: ['-m marker1 and not marker2', '--verbosity=1']
  # ... and the rest
```

> [!NOTE]
> The exact machinations of pytest discovery will be based on the resolution of https://github.com/ACCESS-NRI/build-ci/issues/298

## The PR

* Add new `test-build` dependent job in the `ci.yml` workflow that install the previously installed-and-pushed packages from the lockfile, then runs `pytest`
* Optional args to `pytest` are given at the manifest level via a `_pytest-args` reserved definition in the manifest. 
* Consolidated a large amount of setup code for both jobs under the new `.github/actions/setup-instance` action.

## Testing

### Proof of Concept

Tested in https://github.com/ACCESS-NRI/access-test-component/pull/19, specifically https://github.com/ACCESS-NRI/access-test-component/actions/runs/24760630710?pr=19. Note the tests under `.github/build-ci/tests`, discovered by `inputs.pytest-search-path` (as hidden directories aren't found traditionally. 

Also note the reading of reserved definitions, for example written in https://github.com/ACCESS-NRI/access-test-component/pull/19/changes#diff-b5e432583957cd6026f987a7ddf4b2df3a0daab1e7afd40293562f16c0d6b4b1R3 and added successfully in https://github.com/ACCESS-NRI/access-test-component/actions/runs/24760630710/job/72443635335#step:11:8.

Installation in the test job is _much_ quicker when using a lockfile and `spack install --use-cache` - possibly because we skip concretization and go to querying the buildcache immediately - from 2m with perfect reuse [in the initial install job](https://github.com/ACCESS-NRI/access-test-component/actions/runs/24432348048/job/71379298965?pr=19#step:21:27) to 20s with perfect reuse [in the later test job](https://github.com/ACCESS-NRI/access-test-component/actions/runs/24432348048/job/71379647707?pr=19#step:15:14). 