### PR TITLE
`ci.yml`: Update `access-spack-packages` before `builtin` spack-packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,15 +337,6 @@ jobs:
           echo "builtin=$(spack location --repo builtin)" >> $GITHUB_OUTPUT
           echo "access-spack-packages=$(spack location --repo access.nri)" >> $GITHUB_OUTPUT
 
-      - name: Update - builtin spack-package version
-        id: builtin-spack-packages-update
-        uses: access-nri/build-ci/.github/actions/spack-checkout-updated-ref@v3
-        with:
-          spack-packages-repository-name: builtin
-          spack-packages-repository-path: ${{ steps.spack-packages-locations.outputs.builtin }}
-          ref: ${{ inputs.builtin-spack-packages-ref || steps.get-default-builtin.outputs.ref }}
-          spack-instance-root-path: ${{ steps.env.outputs.SPACK_ROOT }}
-
       - name: Update - access-spack-package version
         id: access-spack-packages-update
         uses: access-nri/build-ci/.github/actions/spack-checkout-updated-ref@v3
@@ -353,6 +344,15 @@ jobs:
           spack-packages-repository-name: access_spack_packages
           spack-packages-repository-path: ${{ steps.spack-packages-locations.outputs.access-spack-packages }}
           ref: ${{ inputs.access-spack-packages-ref }}
+          spack-instance-root-path: ${{ steps.env.outputs.SPACK_ROOT }}
+
+      - name: Update - builtin spack-package version
+        id: builtin-spack-packages-update
+        uses: access-nri/build-ci/.github/actions/spack-checkout-updated-ref@v3
+        with:
+          spack-packages-repository-name: builtin
+          spack-packages-repository-path: ${{ steps.spack-packages-locations.outputs.builtin }}
+          ref: ${{ inputs.builtin-spack-packages-ref || steps.get-default-builtin.outputs.ref }}
           spack-instance-root-path: ${{ steps.env.outputs.SPACK_ROOT }}
 
       - name: Spack - OCI Buildcache Init


### PR DESCRIPTION
## Background

Because of how `spack` merges their configuration information, when we do our `spack repo update builtin` then `spack repo update access_spack_packages` in the `access.nri.ci.user` scope, it flips the precedence of the two repositories. This hasn't really been an issue as we often have mutually exclusive packages, but `mumps` is the exception - it is in both `builtin` and our `access-spack-packages` now. 

See https://github.com/ACCESS-NRI/access-spack-packages/actions/runs/25112191206/job/73589063089?pr=414#step:13:155, you'll note that post-update of `builtin` the precedence of the repositories are flipped:

```
---                                   repos:
/github/home/.spack/repos.yaml:2        builtin:
/github/home/.spack/repos.yaml:3          commit: 2f02a99ec9dfd5dceb9bd91abc392edabd9ba963
/opt/spack-config/v1.1/repos.yaml:8       git: https://github.com/spack/spack-packages.git
/opt/spack-config/v1.1/repos.yaml:11      destination: $spack/../spack-packages
/opt/spack-config/v1.1/repos.yaml:3     access_spack_packages:
/opt/spack-config/v1.1/repos.yaml:4       git: https://github.com/ACCESS-NRI/access-spack-packages.git
/opt/spack-config/v1.1/repos.yaml:5       branch: api-v2
/opt/spack-config/v1.1/repos.yaml:6       destination: $spack/../access-spack-packages
```

## The PR

* Swap the updates of `builtin` and `access-spack-packages` so `access-spack-packages` is done first. 

## Testing

In `ghcr.io/access-nri/build-ci-runner:rocky-v1.1-2026.04.001`, I did the equivalent commands and the config was in the right order of precedence:

```bash
# Before any updates...
[root@7a8f088675ef /]# spack config blame repos
---                                   repos:
/opt/spack-config/v1.1/repos.yaml:3     access_spack_packages:
/opt/spack-config/v1.1/repos.yaml:4       git: https://github.com/ACCESS-NRI/access-spack-packages.git
/opt/spack-config/v1.1/repos.yaml:5       branch: api-v2
/opt/spack-config/v1.1/repos.yaml:6       destination: $spack/../access-spack-packages
/opt/spack-config/v1.1/repos.yaml:7     builtin:
/opt/spack-config/v1.1/repos.yaml:8       git: https://github.com/spack/spack-packages.git
/opt/spack-config/v1.1/repos.yaml:10      commit: 2f02a99ec9dfd5dceb9bd91abc392edabd9ba963
/opt/spack-config/v1.1/repos.yaml:11      destination: $spack/../spack-packages

# First update access-spack-packages...
[root@7a8f088675ef /]# spack repo set --scope=access.nri.ci.user access_spack_packages
==> Updated repo 'access_spack_packages'
[root@7a8f088675ef /]# spack repo update --scope=access.nri.ci.user access_spack_packages --commit 51064dc720f49c49e9680c368201e26081d4fa3f
==> access_spack_packages: Already up to date.

# Then the builtin....
[root@7a8f088675ef /]# spack repo set --scope=access.nri.ci.user builtin
==> Updated repo 'builtin'
[root@7a8f088675ef /]# spack repo update --scope=access.nri.ci.user builtin --commit 8ed34337e15d759890b68682d704aa55dd243537
==> builtin: Updated sucessfully.

# Then we note that the precedence is correct!
[root@7a8f088675ef /]# spack config blame repos
---                                         repos:
/opt/runner/spack-user-config/repos.yaml:2    access_spack_packages:
/opt/runner/spack-user-config/repos.yaml:3      commit: 51064dc720f49c49e9680c368201e26081d4fa3f
/opt/spack-config/v1.1/repos.yaml:4             git: https://github.com/ACCESS-NRI/access-spack-packages.git
/opt/spack-config/v1.1/repos.yaml:5             branch: api-v2
/opt/spack-config/v1.1/repos.yaml:6             destination: $spack/../access-spack-packages
/opt/runner/spack-user-config/repos.yaml:4    builtin:
/opt/runner/spack-user-config/repos.yaml:5      commit: 8ed34337e15d759890b68682d704aa55dd243537
/opt/spack-config/v1.1/repos.yaml:8             git: https://github.com/spack/spack-packages.git
/opt/spack-config/v1.1/repos.yaml:11            destination: $spack/../spack-packages
```
