### PR TITLE
Clone potentially-private manifest repo with `spack install` token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,6 +383,8 @@ jobs:
           repository: ${{ inputs.spack-manifest-repository }}
           ref: ${{ steps.init.outputs.spack-manifest-repository-ref }}
           submodules: recursive
+          # Similarly to the spack install command below, we need to be able to checkout the spack-manifest-repository (which may be private)
+          token: ${{ secrets.spack-install-command-pat || github.token }}
 
       - name: Manifest - Install Compilers Locally
         # Some compilers may not be available upstream, so we install them locally in a separate spack.yaml


### PR DESCRIPTION
See https://github.com/ACCESS-NRI/access-spack-packages/actions/runs/28521219694/job/84566689730?pr=452#step:17:80

## Background

Since a couple of weeks ago, our usual use cases were:

* `build-ci` was called from a potentially private repository, which used a similarly accessible manifest repostiory. For example, a private `ACCESS-NRI/UM7` called `build-ci` with the default manifest repository (itself). It could therefore use the default `github.token`, which can access it's own caller repository. 
* `build-ci` was called from `access-spack-packages`, which used `access-spack-packages` as a manifest respository, just building different packages. These are public repositories, and hence can use the default `github.token`. 

But now, with `access-spack-packages` (and `spack-config`, and soon `upstream-spack-packages`) sourcing manifests from potentially private repositorites (see ACCESS-NRI/access-spack-packages#420), we have a new use case:

* `build-ci` was called from `access-spack-packages` (etc...), which uses a potentially private manifest repository. For example, `access-spack-packages` attempts to build `UM7` using the manifests from `ACCESS-NRI/UM7`, which are private. We can't use the default token, because it doesn't have access to those private repos.

## The PR

* Clone the manifest repository using a supplied `secrets.spack-install-command-pat`, if it exists
