### PR TITLE
Preventing Indirect Access to Private Manifest Repositories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,8 +383,18 @@ jobs:
           repository: ${{ inputs.spack-manifest-repository }}
           ref: ${{ steps.init.outputs.spack-manifest-repository-ref }}
           submodules: recursive
+          # Only checkout the manifests, rather than the entire repository
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |-
+            ${{ inputs.spack-manifest-path }}
+            ${{ inputs.spack-compiler-manifest-path}}
           # Similarly to the spack install command below, we need to be able to checkout the spack-manifest-repository (which may be private)
           token: ${{ secrets.spack-install-command-pat || github.token }}
+
+      - name: Manifest - Delete History From ${{ inputs.spack-manifest-repository }}
+        # Specifically, this is to avoid exposing a private spack manifest repository's history to the actor if they SSH in
+        if: always() && steps.checkout.conclusion == 'success'
+        run: rm -rf ./.git
 
       - name: Manifest - Install Compilers Locally
         # Some compilers may not be available upstream, so we install them locally in a separate spack.yaml


### PR DESCRIPTION
## Background

With the merging of CI for a bunch of `build-ci`-enabled repositories that test across our entire suite of packages (including private packages, see ACCESS-NRI/access-spack-packages#420, ACCESS-NRI/spack-config#95), we have a possibility of a private package being accessible to an actor using the following when they don't have access to the underlying private repository:

```yaml
uses: access-nri/build-ci/.github/workflows/ci.yml@v3
with:
  spack-manifest-repository: access-nri/PRIVATE
  spack-manifest-path: .github/build-ci/manifests/spack.yaml.j2
  allow-ssh-into-spack-install: true
```

Therefore, they gain access to restricted packages through having write access to things like `access-spack-packages`/`upstream-spack-packages`/`spack-config`.

To remove this possibility, we do a sparse clone of the `inputs.spack-manifest-path`, and remove the `.git` directory before allowing SSH access. When SSH'd in, users also don't have access to the `secrets.spack-install-command-pat` that would allow recloning of private repos. 

## The PR

* Sparsely clone the `inputs.spack-manifest-repository` to only include the manifest(s)
* Delete the `.git` directory pre-SSH so actors can't access repo history

## Testing

Tested the sparse checkout and deletion of `.git` in https://github.com/codegat-test-org/test/actions/runs/28765247842/job/85288107897
